### PR TITLE
fix(docs): link to angular-translate corrected

### DIFF
--- a/tech_stack.html
+++ b/tech_stack.html
@@ -17,7 +17,7 @@ sitemap:
 	<li><a href="http://html5boilerplate.com/" target="_blank">HTML5 Boilerplate</a></li>
 	<li><a href="http://getbootstrap.com/" target="_blank">Twitter Bootstrap</a></li>
 	<li><a href="http://angularjs.org/" target="_blank">AngularJS</a></li>
-	<li>Full internationalization support with <a href="https://github.com/PascalPrecht/angular-translate" target="_blank">Angular Translate</a></li>
+	<li>Full internationalization support with <a href="https://github.com/angular-translate/angular-translate" target="_blank">Angular Translate</a></li>
 	<li>
 	Optional <a href="http://compass-style.org/" target="_blank">Compass</a> / Sass support for CSS design</li>
 	<li>Optional WebSocket support with the <a href="http://async-io.org/" target="_blank">Atmosphere framework</a>


### PR DESCRIPTION
Just fixes the URL to the angular-translate project to be up to date
