### PR TITLE
Added missing port redirection for grunt-contrib-watch

### DIFF
--- a/installation.html
+++ b/installation.html
@@ -87,7 +87,7 @@ Run The docker image, with the following options:
 </p>
 <p>
 <code>
-sudo docker run -v ~/jhipster:/jhipster -p 8080:8080 -p 9000:9000 -p 4022:22 -t jdubois/jhipster-docker
+sudo docker run -v ~/jhipster:/jhipster -p 8080:8080 -p 9000:9000 -p 35729:35729 -p 4022:22 -t jdubois/jhipster-docker
 </code>
 </p>
 <p>


### PR DESCRIPTION
See also https://github.com/gruntjs/grunt-contrib-watch#optionslivereload
