### PR TITLE
Change wording in intro

### DIFF
--- a/security.html
+++ b/security.html
@@ -9,7 +9,7 @@ sitemap:
 <h1><i class="fa fa-lock"></i> Securing your application</h1>
 
 <p>
-    Spring Security does not work well with Single Web Page Applications, like JHipster, as it implies you have some specific login/logout/error pages. We have modified Spring Security in order to have AngularJS views work correctly, and of course we generate all those views for you.
+    To use Spring Security with a Single Web Page Applications, like JHipster, you need some login/logout/error pages. We have configured Spring Security in order to have AngularJS views work correctly, and of course we generate all those views for you.
 </p>
 
 <p>


### PR DESCRIPTION
Spring Security works just fine with a SPA (and that's why jhipster is using it). It would be better to say so.