### PR TITLE
Update URL to favicons in default layout.

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -46,8 +46,8 @@
     <![endif]-->
 
     <!-- Favicon with QHD -->
-    <link rel="icon" type="image/png" href="images/favicon-32x32.png" sizes="32x32" />
-    <link rel="icon" type="image/png" href="images/favicon-16x16.png" sizes="16x16" />
+    <link rel="icon" type="image/png" href="/images/favicon-32x32.png" sizes="32x32" />
+    <link rel="icon" type="image/png" href="/images/favicon-16x16.png" sizes="16x16" />
   </head>
 
   <body>


### PR DESCRIPTION
This commit resolves an issue where favicons do not display properly on pages that are not at the root of the site. For example, [this page](http://jhipster.github.io/2015/03/08/jhipster-release-2.6.0.html) does not properly load the favicon.