### PR TITLE
Fix gradle doc

### DIFF
--- a/development.html
+++ b/development.html
@@ -63,7 +63,7 @@ sitemap:
 </p>
 <p>
     <code>
-        gradlew bootRun
+        gradle bootRun
     </code>
 </p>
 


### PR DESCRIPTION
Using an installed gradle, doesn't require using the wrapper with ``gradlew`` (Maybe that paragraph should be removed completely, such that everyone uses the wrapper instead...)