### PR TITLE
Add more IntelliJ directory exclusions

### DIFF
--- a/configuring_ide_idea.md
+++ b/configuring_ide_idea.md
@@ -15,7 +15,8 @@ lastmod: 2015-05-22T18:40:00-00:00
 
 ## Exclude the 'bower_components" from src/main/webapp
 
-- Right-click on the src/main/webapp/bower_components folder
+- Right-click on the `src/main/webapp/bower_components` folder
 - Select "Mark Directory As" and select "Excluded"
+- We also suggest to exclude `.tmp/`, `node_modules/` and `src/main/webapp/dist`
 
 ![Exclude](images/configuring_ide_idea_1.png)


### PR DESCRIPTION
Those are the other repository I ignore. dist and .tmp only appear when I do a production build locally.