### PR TITLE
Update maven command for new deployment

### DIFF
--- a/heroku.html
+++ b/heroku.html
@@ -57,7 +57,7 @@ yo jhipster:heroku
 </p>
 <p>
 <code>
-mvn install -Pprod -DskipTests
+mvn package -Pprod -DskipTests
 </code>
 </p>
 <p>


### PR DESCRIPTION
change the maven goal to 'package' for the following reasons:
* there is no need to install the package in the local maven repository, you just need a packaged war file
* this makes the page in sync with the "Using in production" page