### PR TITLE
change liquibase-hibernate plugin link

### DIFF
--- a/development.html
+++ b/development.html
@@ -208,7 +208,7 @@ sitemap:
     If you have choosen to use MySQL or Postgresql in development, you can use the <code>mvn liquibase:diff</code> goal to automatically generate a changelog.
 </p>
 <p>
-    <a href="http://www.liquibase.org/documentation/maven/index.html" target="_blank">Liquibase Hibernate</a> is a Maven plugin that is configured in your pom.xml, and is independant from your Spring application.yml file, so if you have changed the default settings (for example, changed the database password), you need to modify both files.
+    <a href="https://github.com/liquibase/liquibase-hibernate" target="_blank">Liquibase Hibernate</a> is a Maven plugin that is configured in your pom.xml, and is independant from your Spring application.yml file, so if you have changed the default settings (for example, changed the database password), you need to modify both files.
 </p>
 <p>
     Here is the development workflow:


### PR DESCRIPTION
liquibase hibernate maven plugin is not part of the liquibase product itself but is and independent project
this links to the homepage of the project so the user could find proper documentations