### PR TITLE
Update 004_tip_using_ms_sql_server.md

### DIFF
--- a/tips/004_tip_using_ms_sql_server.md
+++ b/tips/004_tip_using_ms_sql_server.md
@@ -46,8 +46,7 @@ _application-dev.yml_
         profiles:
             active: dev
         datasource:
-            driverClassName: com.microsoft.sqlserver.jdbc.SQLServerDriver
-            dataSourceClassName: com.microsoft.sqlserver.jdbc.SQLServerDataSource
+            driverClassName: com.microsoft.sqlserver.jdbc.SQLServerDataSource
             url: jdbc:sqlserver://localhost:1433;databaseName=test
             databaseName:
             serverName:


### PR DESCRIPTION
I've found that connecting to SQL Server can be simplified by combining the SQLServerDataSource for the driverClassName instead of having to specify them both.