### PR TITLE
Added tip: Configuring HTML 5 mode

### DIFF
--- a/tips.md
+++ b/tips.md
@@ -21,4 +21,4 @@ _If you want to contribute, don't hesitate to send us a Pull Request with your t
 7. [Enforce HTTPS](tips/007_tips_enforce_https.html)
 8. [Create a static Swagger API documentation](tips/008_tips_static_swagger_docs.html)
 9. [Using Bootswatch themes](tips/009_tips_using_bootswatch_themes.html)
-9. [Configuring HTML 5 Mode](tips/010_tip_configuring_html_5_mode.html)
+10. [Configuring HTML 5 Mode](tips/010_tip_configuring_html_5_mode.html)

--- a/tips.md
+++ b/tips.md
@@ -21,3 +21,4 @@ _If you want to contribute, don't hesitate to send us a Pull Request with your t
 7. [Enforce HTTPS](tips/007_tips_enforce_https.html)
 8. [Create a static Swagger API documentation](tips/008_tips_static_swagger_docs.html)
 9. [Using Bootswatch themes](tips/009_tips_using_bootswatch_themes.html)
+9. [Configuring HTML 5 Mode](tips/010_tip_configuring_html_5_mode.html)

--- a/tips/010_tip_configuring_html_5_mode.md
+++ b/tips/010_tip_configuring_html_5_mode.md
@@ -1,0 +1,67 @@
+---
+layout: default
+title: Configuring HTML 5 mode
+sitemap:
+priority: 0.5
+lastmod: 2015-11-04T23:23:00-00:00
+---
+
+# Configuring HTML 5 mode
+
+__Tip submitted by [@brevleq](https://github.com/brevleq)__
+
+As you may noticed, AngularJS uses a "#" in it's urls. HTML5Mode of AngularJS removes these "#" from URL.
+
+## Activate HTML 5 Mode
+
+Open the `app.js` file and add this line in `config` method:
+
+    $locationProvider.html5Mode(true);
+
+Then open `index.html` and add this line in `head` tag:
+
+    <base href="/">
+    
+## Redirection filter     
+    
+Now, to have relative paths links working correctly (ex. activation link sent to user e-mail) we need create a filter to redirect the URI without "#" to a url with "#", so AngularJS can work correctly:
+    
+    public class Html5ModeFilter implements Filter {
+        @Override
+        public void init(FilterConfig filterConfig) throws ServletException {
+            // Nothing to initialize
+        }
+    
+        @Override
+        public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+            HttpServletRequest httpRequest = (HttpServletRequest) request;
+            String requestURI = httpRequest.getRequestURI();
+            if(!requestURI.equals("/") && !requestURI.contains(".html") && StringUtils.countMatches(requestURI,"/")==1) {
+                requestURI = "/#" + requestURI;
+                HttpServletResponse httpResponse = (HttpServletResponse) response;
+                httpResponse.sendRedirect(requestURI);
+                return;
+            }
+            chain.doFilter(request, response);
+        }
+    
+        @Override
+        public void destroy() {
+            // Nothing to destroy
+        }
+    }
+    
+Finally, init the filter in `WebConfigurer` class:
+    
+    public void onStartup(ServletContext servletContext) throws ServletException {
+        ...
+        initHtml5ModeFilter(servletContext, disps);
+        ...
+    }
+    
+    private void initHtml5ModeFilter(ServletContext servletContext, EnumSet<DispatcherType> disps){
+        log.debug("Registering HTML5Mode Filter");
+        FilterRegistration.Dynamic html5ModeFilter = servletContext.addFilter("html5Mode", new Html5ModeFilter());
+        html5ModeFilter.addMappingForUrlPatterns(disps, true, "/*");
+    }
+    


### PR DESCRIPTION
To configure this mode in JHipster, we need more than only set the html5mod flag, we need a Servlet Filter to redirect the urls without #, so activation link can work correctly.