### PR TITLE
fix roles still being called authorities

### DIFF
--- a/creating_a_service.html
+++ b/creating_a_service.html
@@ -77,7 +77,7 @@ sitemap:
 <h2>Can we add security to Service Beans?</h2>
 
 <p>
-  Yes! Just add Spring Security's <code>@Secured</code> annotation on your class or on your methods, and use the provided AuthoritiesConstants class to restrict access to specific user roles.
+  Yes! Just add Spring Security's <code>@Secured</code> annotation on your class or on your methods, and use the provided AuthoritiesConstants class to restrict access to specific user authorities.
 </p>
 
 <h2>Can we monitor Service Beans?</h2>

--- a/using_angularjs.md
+++ b/using_angularjs.md
@@ -63,11 +63,11 @@ When generating a new entity Foo with `yo jhipster:entity Foo` the following fro
 
 JHipster uses [angular-ui-router](http://angular-ui.github.io/ui-router/) to organize the different parts of your client application.
 
-For each state, the required roles are listed in the state's data, and when the role list is empty it means that the state can be accessed anonymously.
+For each state, the required authorities are listed in the state's data, and when the authority list is empty it means that the state can be accessed anonymously.
 
-The role names are defined in server's class AuthoritiesConstants.java.
+The authority names are defined in server's class AuthoritiesConstants.java.
 
-In the example below, the 'sessions' state can be accessed only by authenticated users who have ROLE_USER role:
+In the example below, the 'sessions' state can be accessed only by authenticated users who have ROLE_USER authority:
 
     angular.module('hipster2App')
         .config(function ($stateProvider) {
@@ -76,7 +76,7 @@ In the example below, the 'sessions' state can be accessed only by authenticated
                     parent: 'account',
                     url: '/sessions',
                     data: {
-                        roles: ['ROLE_USER']
+                        authorities: ['ROLE_USER']
                     },
                     views: {
                         'content@': {


### PR DESCRIPTION
fix roles still being called authorities in docs after 2.21.0

fix jhipster/generator-jhipster#2396