### PR TITLE
Added explanations to use devTools in IntelliJ

### DIFF
--- a/configuring_ide_idea.md
+++ b/configuring_ide_idea.md
@@ -3,7 +3,7 @@ layout: default
 title: Configuring your IDE
 sitemap:
 priority: 0.7
-lastmod: 2015-05-22T18:40:00-00:00
+lastmod: 2015-11-28T17:13:00-00:00
 ---
 
 # <i class="fa fa-keyboard-o"></i> Configuring Intellij IDEA

--- a/configuring_ide_idea.md
+++ b/configuring_ide_idea.md
@@ -57,3 +57,9 @@ Navigate to `Languages & Frameworks → Javascript → Bower` (or type "Bower" o
 Point to your `bower.json`, which is located at the root of your project. The project's libraries, like Angular.js, should be automatically recognized.
 
 After configuring this you should have fairly extensive code support for the Javascript libraries in JHipster.
+
+## Java classes hot reload with devTools
+
+Contrary to other IDEs such as Eclipse, IntelliJ IDEA does not automatically compile files after saving. While you could enable "Make project automatically" in the complier options, it does not work when your application is already running from the IDE.
+
+The best way to reload the application after you modified a class is compile it with `Ctrl + Shift + F9` or to build the whole project with `Shift + F9`. Alternatively, you can build with a single class from the class file contextual menu by clicking on `Compile className.java` or build the whole project through the `Build → Make project` menu at the top.


### PR DESCRIPTION
Since Eclipse and IntelliJ work differently and following jhipster/generator-jhipster#2242, I updated the documentation to show how to use devtools in IntelliJ IDEA.