### PR TITLE
add elasticsearch-reindexer

### DIFF
--- a/modules/marketplace/data/modules.json
+++ b/modules/marketplace/data/modules.json
@@ -129,5 +129,15 @@
         "description": "Stateless Basic authentication support for the API",
         "keywords": ["basic", "authentication", "api"],
         "verified": false
+    },
+    {
+        "name": "Elasticsearch Reindexer",
+        "npmPackageName": "generator-jhipster-elasticsearch-reindexer",
+        "url": "https://github.com/geraldhumphries/generator-jhipster-elasticsearch-reindexer",
+        "author": "Gerald Humphries",
+        "authorUrl": "https://geraldhumphries.com/",
+        "description": "Add a service to reindex all JHipster entities in Elasticsearch",
+        "keywords": ["elasticsearch", "entity", "index"],
+        "verified": false
     }
 ]


### PR DESCRIPTION
This module will add a service to reindex all rows for each JHipster entity in Elasticsearch. This is useful if any changes have been made to the data outside of the application, like inserting rows using liquibase or migrating data from another DB. It works by reading all the json files from the `.jhipster` folder.

This is a solution I developed for my own project and decided to make it a module. There might be a better solution out there, but so far I haven't found one.