### PR TITLE
Add link generator-jhipster-module to the page creating a module

### DIFF
--- a/modules/creating_a_module.md
+++ b/modules/creating_a_module.md
@@ -20,7 +20,7 @@ The [JHipster Fortune module](https://github.com/jdubois/generator-jhipster-fort
 
 It is our sample module that showcases how you can JHipster's variables and functions in order to create your own generator.
 
-Or, you can use the [JHipster module](https://github.com/pascalgrimaud/generator-jhipster-module) to help you to initialize your module.
+Or, you can use the [JHipster module generator](https://github.com/jhipster/generator-jhipster-module) to help you to initialize your module.
 
 ## Basic rules for a JHipster module
 

--- a/modules/creating_a_module.md
+++ b/modules/creating_a_module.md
@@ -20,6 +20,8 @@ The [JHipster Fortune module](https://github.com/jdubois/generator-jhipster-fort
 
 It is our sample module that showcases how you can JHipster's variables and functions in order to create your own generator.
 
+Or, you can use the [JHipster module](https://github.com/pascalgrimaud/generator-jhipster-module) to help you to initialize your module.
+
 ## Basic rules for a JHipster module
 
 A JHipster module:


### PR DESCRIPTION
As suggested by @geraldhumphries in this https://github.com/jhipster/jhipster.github.io/pull/159
It will help users who decide to create a module to start faster