### PR TITLE
home link in nav bar work after html5mode

### DIFF
--- a/tips/010_tip_configuring_html_5_mode.md
+++ b/tips/010_tip_configuring_html_5_mode.md
@@ -58,3 +58,6 @@ Then do the same with webapp\scripts\app\admin\metrics\metrics.js:
 
     url: '/metrics' -> url: '/appmetrics'
     
+Finally, to make the home link in the navigation bar work, open webapp\scripts\components\navbar\navbar.html and change:
+
+    <a class="navbar-brand" href="#/"> -> <a class="navbar-brand" href="/">


### PR DESCRIPTION
The "home" link in the navigation bar breaks after making the changes in the tip - this step fixes it. 