### PR TITLE
Fixed H2 console URL in doc 

### DIFF
--- a/pages/development.html
+++ b/pages/development.html
@@ -159,7 +159,7 @@ sitemap:
 <h2>Using the database</h2>
 <h3>Using the H2 database in development</h3>
 <p>
-    If you choose the H2 database, you will have an in-memory database running inside your application, and you can access its console at <a href="http://localhost:8080/console" target="_blank">http://localhost:8080/console</a> by default.
+    If you choose the H2 database, you will have an in-memory database running inside your application, and you can access its console at <a href="http://localhost:8080/h2-console" target="_blank">http://localhost:8080/h2-console</a> by default.
 </p>
 <p>
     To connect to the database, select the pre-configured options:


### PR DESCRIPTION
It is now /h2-console and no longer /console