### PR TITLE
remove enum from list of supported entity field types for cassandra in jhipster uml page

### DIFF
--- a/pages/jhipster_uml.md
+++ b/pages/jhipster_uml.md
@@ -880,7 +880,7 @@ Here is the type table (from **lib/types/*_types.js**):
   <tr>
     <td>Enum</td>
     <td>Enum</td>
-    <td>Enum</td>
+    <td></td>
     <td><dfn>required</dfn></td>
   </tr>
   <tr>


### PR DESCRIPTION
relates to jhipster/generator-jhipster#2854