### PR TITLE
Add minimum required version of Java

### DIFF
--- a/pages/installation.html
+++ b/pages/installation.html
@@ -26,7 +26,7 @@ sitemap:
 
 <h2>Local installation (recommended for normal users)</h2>
 <ol>
-    <li>Install Java from <a href="http://www.oracle.com/technetwork/java/javase/downloads/index.html" target="_blank">the
+    <li>Install Java Platform (JDK) 8 from <a href="http://www.oracle.com/technetwork/java/javase/downloads/index.html" target="_blank">the
         Oracle website</a>.
     </li>
     <li>(Optional) Install a Java build tool.


### PR DESCRIPTION
Users need to know which Java version they can use with jhipster. It needs at least 8 version of Java. The 7 version is deprecated for jhipster.