### PR TITLE
HTML5Mode Tip update with new AngularJSForwardController class

### DIFF
--- a/tips/010_tip_configuring_html_5_mode.md
+++ b/tips/010_tip_configuring_html_5_mode.md
@@ -3,12 +3,12 @@ layout: default
 title: Configuring HTML 5 mode
 sitemap:
 priority: 0.5
-lastmod: 2015-11-04T23:23:00-00:00
+lastmod: 2016-03-07T23:23:00-00:00
 ---
 
 # Configuring HTML 5 mode
 
-__Tip submitted by [@brevleq](https://github.com/brevleq)__
+__Tip submitted by [@brevleq](https://github.com/brevleq) and updated by [@wmarques](https://github.com/wmarques)__
 
 As you may noticed, AngularJS uses a "#" in it's urls. HTML5Mode of AngularJS removes these "#" from URL.
 
@@ -21,43 +21,29 @@ Open the `app.js` file and add this line in `config` method:
 Then open `index.html` and add this line in `head` tag:
 
     <base href="/">
-    
+
 ## Redirection filter     
-    
+
 Now, to have relative paths links working correctly (ex. activation link sent to user e-mail) we will create a controller to forward the URI to index.html:
-    
+
     @Controller
-    public class AngularJSForwardController {
-
-        private final Logger log = LoggerFactory.getLogger(AngularJSForwardController.class);
-
-        @RequestMapping(value = {"/login**","/activate*","/password*","/register*","/reset/finish*",
-                                 "/reset/request*","/sessions*","/settings*","/social-register/*",
-                                 "/audits*","/configuration*","/docs*","/apphealth*","/logs*","/appmetrics*",
-                                 "/user-management*","/user-management/*","/error*","/accessdenied*"},
-                                  method = RequestMethod.GET)
-        public void pageForward(HttpServletRequest httpRequest, HttpServletResponse httpResponse) {
-            forward(httpRequest, httpResponse);
-        }           
-
-        private void forward(HttpServletRequest httpRequest, HttpServletResponse httpResponse) {
-            RequestDispatcher dispatcher = httpRequest.getRequestDispatcher("/index.html");
-            try {
-                dispatcher.forward(httpRequest, httpResponse);
-            } catch (Exception e) {
-                log.error("Error forwarding request", e);
-            }
+    public class AngularJsForwardController {
+        @RequestMapping(value = "/{[path:[^\\.]*}")
+        public String redirect() {
+            return "forward:/";
         }
     }
-    
-Also, you have to edit urls of the metric.js and health.js. First, open webapp\scripts\app\admin\health\health.js and change:
+
+Please note that this can cause conflicts with [Spring actuators URLs](https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-endpoints.html).
+
+That's why you have to edit urls of the `metric.js` and `health.js`. First, open `webapp\scripts\app\admin\health\health.js` and change:
 
     url: '/health' -> url: '/apphealth'
-    
-Then do the same with webapp\scripts\app\admin\metrics\metrics.js:
+
+Then do the same with `webapp\scripts\app\admin\metrics\metrics.js`:
 
     url: '/metrics' -> url: '/appmetrics'
-    
-Finally, to make the home link in the navigation bar work, open webapp\scripts\components\navbar\navbar.html and change:
+
+Finally, to make the home link in the navigation bar work, open `webapp\scripts\components\navbar\navbar.html` and change:
 
     <a class="navbar-brand" href="#/"> -> <a class="navbar-brand" href="/">


### PR DESCRIPTION
Fix #210.
Started my work on master branch instead of v3_preparation one, sorry.

As asked in this [issue](https://github.com/jhipster/generator-jhipster/issues/2965), I updated the tip made by @brevleq by updating the `AngularJsForwardController` class following [this Spring Guide](https://spring.io/blog/2015/05/13/modularizing-the-client-angular-js-and-spring-security-part-vii).