### PR TITLE
Fix link to marketplace

### DIFF
--- a/presentation/index.html
+++ b/presentation/index.html
@@ -445,7 +445,7 @@ public void saveAccount(@RequestBody UserDTO userDTO) {
                             <li>JHipster Registry (Netflix Eureka + Spring cloud config server) provided out of the box</li>
                             <li>JHipster Console with ELK (Elasticsearch + Logstash + Kibana) monitoring out of the box</li>
                             <li>Great support for Docker</li>
-                            <li>Additional JHipster <a href="https://localhost:4000/modules/marketplace/" target="_blank">Modules</a> to add more features</li>
+                            <li>Additional JHipster <a href="https://jhipster.github.io/modules/marketplace/" target="_blank">Modules</a> to add more features</li>
                         </ul>
                     </section>
                     <section>


### PR DESCRIPTION
Old url points to localhost instead of jhipster.github.io