### PR TITLE
Adding Jekyll Docker command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,8 @@ To run this locally
 * [Install Jekyll](https://help.github.com/articles/using-jekyll-with-pages/#installing-jekyll)
 * Run `bundle exec jekyll serve` in the cloned repo folder
 * you will be able to access the site at http://localhost:4000
+
+Or with Docker
+* [Fork this](https://github.com/jhipster/jhipster.github.io/fork) repo and clone to your file system
+* `docker run --rm --label=jekyll --volume=$(pwd):/srv/jekyll   -it -p 127.0.0.1:4000:4000 jekyll/jekyll:pages`
+* you will be able to access the site at http://localhost:4000


### PR DESCRIPTION
I think we should add the @pascalgrimaud amazing docker command in readme, it's much easier to run Jekyll this way instead of installing it manually.