### PR TITLE
Remove `-preview` from Heroku Button URL

### DIFF
--- a/pages/microservices_architecture.md
+++ b/pages/microservices_architecture.md
@@ -292,7 +292,7 @@ The [Heroku sub-generator]({{ site.url }}/heroku/) works nearly the same with a 
 
 Deploy a JHipster Registry directly with one click:
 
-[![Deploy to Heroku](https://camo.githubusercontent.com/c0824806f5221ebb7d25e559568582dd39dd1170/68747470733a2f2f7777772e6865726f6b7563646e2e636f6d2f6465706c6f792f627574746f6e2e706e67)](https://dashboard-preview.heroku.com/new?&template=https%3A%2F%2Fgithub.com%2Fjhipster%2Fjhipster-registry)
+[![Deploy to Heroku](https://camo.githubusercontent.com/c0824806f5221ebb7d25e559568582dd39dd1170/68747470733a2f2f7777772e6865726f6b7563646e2e636f6d2f6465706c6f792f627574746f6e2e706e67)](https://dashboard.heroku.com/new?&template=https%3A%2F%2Fgithub.com%2Fjhipster%2Fjhipster-registry)
 
 Please follow the [Heroku sub-generator documentation]({{ site.url }}/heroku/) in order to understand how to secure your JHipster Registry.
 


### PR DESCRIPTION
This was a pre-release thing, and I never should have had it in there (whoops)