### PR TITLE
replaced gradelw with gradlew on creating-an-app page

### DIFF
--- a/pages/creating_an_app.md
+++ b/pages/creating_an_app.md
@@ -34,7 +34,7 @@ To generate your application, type:
 
 Answer the questions asked by the generator to create an application tailored to your needs. Those options are described in [the next section](#2).
 
-Once the application is generated, you can launch it using Maven (`./mvnw` on Linux/MacOS/Windows PowerShell, `mvnw` on Windows Cmd) or Gradle (`./gradlew` on Linux/MacOS/Windows PowerShell, `gradelw` on Windows Cmd). You can go the [Using JHipster in development]({{ site.url }}/development/) page for more information.
+Once the application is generated, you can launch it using Maven (`./mvnw` on Linux/MacOS/Windows PowerShell, `mvnw` on Windows Cmd) or Gradle (`./gradlew` on Linux/MacOS/Windows PowerShell, `gradlew` on Windows Cmd). You can go the [Using JHipster in development]({{ site.url }}/development/) page for more information.
 
 The application will be available on [http://localhost:8080](http://localhost:8080)
 


### PR DESCRIPTION
There is a typo on https://jhipster.github.io/creating-an-app/ page: "gradelw". This PR replaces it with correct command: "gradlew".