### PR TITLE
docker-compose: add _JAVA_OPTIONS

### DIFF
--- a/pages/docker_compose.md
+++ b/pages/docker_compose.md
@@ -237,14 +237,24 @@ In order to optimize memory usage for applications running in the container, you
 
 Set the environment variable.
 
-    ENV JAVA_OPTS=-Xmx512m -Xmx256m
+    ENV JAVA_OPTS=-Xmx512m -Xms256m
 
 ### Adding memory parameters to docker-compose.yml
 
 This solution is desired over Dockerfile. In this way, you have a single control point for your memory configuration on all containers that compose you application.
 
-Add the JAVA_OPTS into `environment` section.
+Add the `JAVA_OPTS` into `environment` section.
 
+```
     environment:
       - (...)
-      - JAVA_OPTS=-Xmx512m -Xmx256m
+      - JAVA_OPTS=-Xmx512m -Xms256m
+```
+
+Depending on the Docker base image, `JAVA_OPTS` won't work. In this case, try to use `_JAVA_OPTIONS` instead:
+
+```
+    environment:
+      - (...)
+      - _JAVA_OPTIONS=-Xmx512m -Xms256m
+```


### PR DESCRIPTION
Related to https://github.com/jhipster/generator-jhipster/issues/3791 and https://github.com/jhipster/jhipster.github.io/pull/283

I confirm what @danielbrutti said, about _JAVA_OPTIONS. Big thanks to him.
I needed this to reduce the memory use of all containers

It probably depends on the Docker base image, because I was pretty sure JAVA_OPTS should work.

Here all my tests:

**jhipster-registry.yml** :
```yaml 
version: '2'
services:
    jhipster-registry:
        container_name: jhipster-registry
        image: jhipster/jhipster-registry:v2.5.0
        volumes:
            - ./central-server-config:/central-config
        # When run with the "dev" Spring profile, the JHipster Registry will
        # read the config from the local filesystem (central-server-config directory)
        # When run with the "prod" Spring profile, it will read the config from a git repository
        # See http://jhipster.github.io/microservices-architecture/#registry_app_configuration
        environment:
            - SPRING_PROFILES_ACTIVE=dev
            - SECURITY_USER_PASSWORD=admin
            - SPRING_CLOUD_CONFIG_SERVER_NATIVE_SEARCH_LOCATIONS=file:./central-config/localhost-config/
            # - GIT_URI=https://github.com/jhipster/jhipster-registry/
            # - GIT_SEARCH_PATHS=central-config
        ports:
            - 8761:8761
```

**jhipster-registry-java-opts.yml** :
```yaml
version: '2'
services:
    jhipster-registry-java-opts:
        container_name: jhipster-registry-java-opts
        image: jhipster/jhipster-registry:v2.5.0
        volumes:
            - ./central-server-config:/central-config
        # When run with the "dev" Spring profile, the JHipster Registry will
        # read the config from the local filesystem (central-server-config directory)
        # When run with the "prod" Spring profile, it will read the config from a git repository
        # See http://jhipster.github.io/microservices-architecture/#registry_app_configuration
        environment:
            - JAVA_OPTS=-Xmx512m -Xms256m
            - SPRING_PROFILES_ACTIVE=dev
            - SECURITY_USER_PASSWORD=admin
            - SPRING_CLOUD_CONFIG_SERVER_NATIVE_SEARCH_LOCATIONS=file:./central-config/localhost-config/
            # - GIT_URI=https://github.com/jhipster/jhipster-registry/
            # - GIT_SEARCH_PATHS=central-config
        ports:
            - 8761
```

**jhipster-registry-java-options.yml** :
```yaml
version: '2'
services:
    jhipster-registry-java-options:
        container_name: jhipster-registry-java-options
        image: jhipster/jhipster-registry:v2.5.0
        volumes:
            - ./central-server-config:/central-config
        # When run with the "dev" Spring profile, the JHipster Registry will
        # read the config from the local filesystem (central-server-config directory)
        # When run with the "prod" Spring profile, it will read the config from a git repository
        # See http://jhipster.github.io/microservices-architecture/#registry_app_configuration
        environment:
            - _JAVA_OPTIONS=-Xmx512m -Xms256m
            - SPRING_PROFILES_ACTIVE=dev
            - SECURITY_USER_PASSWORD=admin
            - SPRING_CLOUD_CONFIG_SERVER_NATIVE_SEARCH_LOCATIONS=file:./central-config/localhost-config/
            # - GIT_URI=https://github.com/jhipster/jhipster-registry/
            # - GIT_SEARCH_PATHS=central-config
        ports:
            - 8761
```

Here my `docker stats $(docker ps --format={{.Names}})` :
```
CONTAINER                        CPU %               MEM USAGE / LIMIT       MEM %               NET I/O             BLOCK I/O             PIDS
jhipster-registry-java-options   0.69%               367.4 MiB / 7.419 GiB   4.84%               8.524 kB / 648 B    1.688 MB / 12.76 MB   55
jhipster-registry-java-opts      0.86%               847.4 MiB / 7.419 GiB   11.15%              10.36 kB / 648 B    0 B / 28.61 MB        55
jhipster-registry                0.83%               916.2 MiB / 7.419 GiB   12.06%              14.42 kB / 648 B    60.69 MB / 4.317 MB   55
```