### PR TITLE
Fix Spring Boot Cloud Foundry URL reference

### DIFF
--- a/pages/cloudfoundry.md
+++ b/pages/cloudfoundry.md
@@ -54,5 +54,5 @@ You can also run the sub-generator again, by typing another time:
 
 ## More information
 
-*   [Spring Boot Cloud Foundry documentation](http://docs.spring.io/spring-boot/docs/current/reference/html/cloud-deployment-cloud-foundry.html)
+*   [Spring Boot Cloud Foundry documentation](http://docs.spring.io/spring-boot/docs/current/reference/html/cloud-deployment.html)
 *   [Spring Cloud Connectors](http://cloud.spring.io/spring-cloud-connectors/)


### PR DESCRIPTION
Existing URL points to a 404. Fix the URL page to point to the correct page.