### PR TITLE
fix html5 tip request mapping

### DIFF
--- a/tips/010_tip_configuring_html_5_mode.md
+++ b/tips/010_tip_configuring_html_5_mode.md
@@ -40,7 +40,7 @@ Now, to have relative paths links working correctly (ex. activation link sent to
 
     @Controller
     public class AngularJsForwardController {
-        @RequestMapping(value = "/{[path:[^\\.]*}")
+        @RequestMapping(value = "/**/{[path:[^\\.]*}")
         public String redirect() {
             return "forward:/";
         }


### PR DESCRIPTION
Currently anything with more than one `/` fails on refresh (for example `/user/admin`)