### PR TITLE
Remove obsolete refs to MongoGeez

### DIFF
--- a/pages/cloudfoundry.md
+++ b/pages/cloudfoundry.md
@@ -26,10 +26,6 @@ As this sub-generator uses the Cloud Foundry command-line tool, it can deploy to
 *   [IBM Bluemix](https://console.ng.bluemix.net/)
 *   And of course your own private Cloud Foundry instance if you have decided to install Cloud Foundry yourself!
 
-## Limitations
-
-*   MongoDB cannot load its data with Mongeez because of [#733](https://github.com/jhipster/generator-jhipster/issues/733).
-
 ## Running the sub-generator
 
 Before running the sub-generator, you need to install the [cf Command Line Interface (CLI)](http://docs.cloudfoundry.org/devguide/installcf/), and have a Cloud Foundry account created.

--- a/pages/using_mongodb.html
+++ b/pages/using_mongodb.html
@@ -19,7 +19,7 @@ sitemap:
     When MongoDB is selected:
     <ul>
         <li>Spring Data MongoDB will be used to access the database. This is very close to Spring Data JPA, and this is why MongoDB support is very close to the (default) JPA support</li>
-        <li><a href="https://github.com/secondmarket/mongeez" target="_blank">Mongeez</a> is used instead of <a href="http://www.liquibase.org/" target="_blank">Liquibase</a> to manage database changes</li>
+        <li><a href=https://github.com/mongobee/mongobee" target="_blank">Mongobee</a> is used instead of <a href="http://www.liquibase.org/" target="_blank">Liquibase</a> to manage database changes</li>
         <li>The <a href="{{ site.url }}/creating-an-entity/">entity sub-generator</a> will not ask you for entity relationships, as you can't have relationships with a NoSQL database (at least not in the way you have relationships with JPA)</li>
         <li><a href="https://github.com/flapdoodle-oss/de.flapdoodle.embed.mongo">de.flapdoodle.embed.mongo</a> is used to run an in-memory version of the database for running unit tests.</li>
     </ul>


### PR DESCRIPTION
MongoGeez has been replaced MongoBee: by https://github.com/jhipster/generator-jhipster/issues/733