### PR TITLE
update gradle tip in order to be consistent with the current master

### DIFF
--- a/tips/021_tip_prevent_error_and_hanging_on_windows_when_using_gradle.md
+++ b/tips/021_tip_prevent_error_and_hanging_on_windows_when_using_gradle.md
@@ -59,7 +59,7 @@ tasks.withType(NodeTask) {
         println()
     }
 }
-tasks.withType(com.moowork.gradle.node.npm.NpmInstallTask) {
+tasks.withType(com.moowork.gradle.node.npm.NpmTask) {
     doLast {
         println()
     }


### PR DESCRIPTION
commit https://github.com/jhipster/generator-jhipster/commit/88ba738f406b656ae1e9dd68517dac33929a290c changed npmInstall to npm_install
so in hack must use more general npm class NpmTask