### PR TITLE
Update ci cd

### DIFF
--- a/pages/configuring-ide-visual-studio-code.md
+++ b/pages/configuring-ide-visual-studio-code.md
@@ -57,7 +57,7 @@ If you use the JHipster App, this is only a matter of clicking on 2 buttons (one
 
 For best performance, it's recommended to exclude some folders, in your project's `.vscode` folder create a `settings.json` file as below:
 
-{% highlight javascript %}
+```
 {
     // Configure glob patterns for excluding files and folders.
     "files.exclude": {
@@ -76,4 +76,4 @@ For best performance, it's recommended to exclude some folders, in your project'
         "**/target": true
     }
 }
-{% endhighlight %}
+```

--- a/pages/setting_up_ci.md
+++ b/pages/setting_up_ci.md
@@ -52,10 +52,26 @@ The tasks/integrations you want to include in the Jenkins pipeline:
 - Perform the build in a Docker container
 - Analyze code with Sonar
 - Send build status to Gitlab
+- Build and publish a Docker image
+
+**Note**: when you select Jenkins pipeline, a new `src/main/docker/jenkins.yml` file will be generated.
+So you can test Jenkins locally by running:
+
+```
+docker-compose -f src/main/docker/jenkins.yml up -d
+```
 
 ### What is the name of the Sonar server ?
 
 Choose the name of the Sonar server.
+
+### What is the URL of the Docker registry ?
+
+By default, you can use Docker Hub: [https://registry.hub.docker.com](https://registry.hub.docker.com)
+
+### What is the Jenkins Credentials ID for the Docker registry ?
+
+By default, you can use: `docker login`
 
 ### In GitLab CI perform the build in a docker container (hint: gitlab.com uses docker container)?
 


### PR DESCRIPTION
1st commit:
- use default syntax to be consistent and to fix the error I got locally:
```
Configuration file: /site/_config.yml
            Source: /site
       Destination: /site/_site
      Generating... 
  Liquid Exception: Failed to get header. in pages/configuring-ide-visual-studio-code.md
```

2nd commit: update the ci-cd page with the 2 PR:
- by @PierreBesson : https://github.com/jhipster/generator-jhipster/pull/5367
- by @cbornet : https://github.com/jhipster/generator-jhipster/pull/5361

@jdubois : you can merge it for the **next** release