### PR TITLE
improve elasticsearch docs

### DIFF
--- a/pages/using_elasticsearch.md
+++ b/pages/using_elasticsearch.md
@@ -6,7 +6,7 @@ redirect_from:
   - /using_elasticsearch.html
 sitemap:
     priority: 0.7
-    lastmod: 2016-11-21T00:00:00-00:00
+    lastmod: 2017-04-16T00:00:00-00:00
 ---
 
 # <i class="fa fa-search"></i> Using Elasticsearch
@@ -17,20 +17,27 @@ This option has some limitations:
 
 *   It only works with SQL databases. MongoDB and Cassandra support will be added in the future (help is welcome!).
 *   There is no consistency between your database and Elasticsearch, so you might have out-of-sync data. This is normal, as Elasticsearch is not a real database. As a result, you will probably need to write some specific code to synchronize your data, for example using the Spring `@Scheduled` annotation, to run every evening.
+    *   This also means if your database is changed outside of your application, your search indexes will be out-of-sync.  The [Elasticsearch Reindexer](https://jhipster.github.io/modules/marketplace/#/details/generator-jhipster-elasticsearch-reindexer) JHipster module can help in these situations.
 
 When the Elasticsearch option is selected:
 
 *   Spring Data Elasticsearch is being used, and is automatically configured by Spring Boot ([here is the documentation](http://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-nosql.html#boot-features-elasticsearch)).
-*   By default, we use an embedded Elasticsearch in development, and try to connect to a local cluster in production. This can be configured by the standard Spring Boot properties, in the `application.yml` file.  
-    When using the dev profile, the embedded Elasticsearch is configured to store data files under the target folder, a simple `mvn clean` will destroy the persisted indices.
 *   The "repository" package has new subpackage, called "search", that holds all ElastiSearch repositories.
 *   The "User" entity gets indexed in Elasticsearch, and you can query is using the `/api/_search/users/:query` REST endpoint.
 *   When the [entity sub-generator]({{ site.url }}/creating-an-entity/) is used, the generated entity gets automatically indexed by Elasticsearch, and is used in the REST endpoint. Search capabilities are also added to the AngularJS user interface, so you can search your entity in the main CRUD screen.
-*   When using dev profile, you can enable http access by adding this configuration in `application-dev.yml` :
 
+### Using in Development
+
+In development, JHipster uses an embedded Elasticsearch cluster.  The embedded instance is configured to store data files under the target folder, a simple `mvn clean` will destroy the persisted indices.  You will need to re-index your data if this happens.
+
+You can enable http access by adding this configuration in `application-dev.yml` :
 ```
 elasticsearch:
   properties:
       http:
           enabled: true
 ```
+
+### Using in Production
+
+In production, JHipster expects an external Elasticsearch instance.  By default, the app looks for Elasticsearch running on localhost.  This can be configured by the standard Spring Boot properties, in the `application-prod.yml` file.


### PR DESCRIPTION
Main change was separating the information into dev/prod specific sections.  I also mentioned the Elasticsearch Reindexer which is really helpful when Elasticsearch is out of sync with the database.

Related to https://github.com/jhipster/generator-jhipster/issues/5499