### PR TITLE
Use simple google link for searching 

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -89,6 +89,9 @@
                         </li>
                         {% endif %}
                         <li class="">
+                            <a href="https://www.google.com/search?q=site:www.jhipster.tech" target="_blank">Search</a>
+                        </li>                        
+                        <li class="">
                             <a href="https://github.com/jhipster/generator-jhipster" class="dropdown-toggle navlink" target="_blank" role="button"><i class="fa fa-github fa-2x"></i></a>
                         </li>
                     </ul>
@@ -341,22 +344,6 @@
                                             </li>
                                         </ul>
                                     </div>
-                                    <div class="footer-col col-md-4 google-search">
-                                        <script>
-                                            (function () {
-                                                var cx = '004687894124070278856:-ryvp1pk0xi';
-                                                var gcse = document.createElement('script');
-                                                gcse.type = 'text/javascript';
-                                                gcse.async = true;
-                                                gcse.src = (document.location.protocol == 'https:' ? 'https:' : 'http:') +
-                                                    '//cse.google.com/cse.js?cx=' + cx;
-                                                var s = document.getElementsByTagName('script')[0];
-                                                s.parentNode.insertBefore(gcse, s);
-                                            })();
-                                        </script>
-                                        <gcse:search></gcse:search>
-
-                                    </div>
                                 </div>
                             </div>
                         </div>
@@ -364,7 +351,7 @@
                             <div class="container">
                                 <div class="row">
                                     <div class="col-lg-12">
-                                        Copyright &copy; JHipster 2016 | Theme based on <a href="https://github.com/IronSummitMedia/startbootstrap-freelancer" target="_blank">Freelancer</a> and <a href="https://github.com/tui2tone/flat-admin-bootstrap-templates" target="_blank">Flat admin</a>
+                                        Copyright &copy; JHipster 2017 | Theme based on <a href="https://github.com/IronSummitMedia/startbootstrap-freelancer" target="_blank">Freelancer</a> and <a href="https://github.com/tui2tone/flat-admin-bootstrap-templates" target="_blank">Flat admin</a>
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
- Removed search box from page footer
- Add a link to Google in top navbar

Fix jhipster/generator-jhipster#6375