### PR TITLE
add gradle setup hint

### DIFF
--- a/pages/configuring_ide_idea.md
+++ b/pages/configuring_ide_idea.md
@@ -89,6 +89,4 @@ Open the "Maven Projects" tool window (View -> Tool Windows), check the `IDE` ma
 
 ## Gradle 
 
-In order to get best out of box experience you should delegate all [ide build/run actions to gradle](https://www.jetbrains.com/idea/whatsnew/#v2017-3-gradle) directly. With this setting annotation processing works out of the box
-and you won't have duplicated classes when mixing ide and cli builds. If you are using an older version ( < 2016.3) you have to enable 
-annotaion processing manually.
+In order to get the best out-of-the-box experience with Gradle you should delegate all [IDE build/run actions to Gradle](https://www.jetbrains.com/idea/whatsnew/#v2017-3-gradle) directly. With this setting annotation processing is automatically configured and you won't have duplicated classes when mixing IDE and cli builds. If you are using an older version ( < 2016.3) you have to enable annotaion processing manually.

--- a/pages/configuring_ide_idea.md
+++ b/pages/configuring_ide_idea.md
@@ -86,3 +86,9 @@ If you are using Maven, you need to activate the `IDE` profile in IntelliJ. This
 which currently only includes applying the MapStruct annotation processor.
 
 Open the "Maven Projects" tool window (View -> Tool Windows), check the `IDE` maven profile to activate it.
+
+## Gradle 
+
+In order to get best out of box experience you should delegate all [ide build/run actions to gradle](https://www.jetbrains.com/idea/whatsnew/#v2017-3-gradle) directly. With this setting annotation processing works out of the box
+and you won't have duplicated classes when mixing ide and cli builds. If you are using an older version ( < 2016.3) you have to enable 
+annotaion processing manually.


### PR DESCRIPTION
Adding a section about recommended setup when using gradle. In case you don't forward ide builds to gradle annotation processing must be enabled manually and when mixing ide and cli builds one will get duplicated classes as idea puts its compiled classes into a different location than gradle does.

For reference:
* https://github.com/tbroyer/gradle-apt-plugin#intellij-idea
* https://www.jetbrains.com/idea/whatsnew/#v2017-3-gradle

I will try to update the apt plugins and gradle to the latest version (which might fix the eclipse problem) in the next few days.