### PR TITLE
add mention of the gitter chat on the team's page

### DIFF
--- a/pages/team.md
+++ b/pages/team.md
@@ -209,7 +209,11 @@ JHipster is developed by a team of people around the world. We have a lot of con
 
 We do most of our work on [the project's GitHub page](https://github.com/jhipster/generator-jhipster).
 
-We also have our own mailing list: it is publicly viewable, as everything we do in JHipster is public, but only the board of developers can send e-mails to the list. It is available [here](https://groups.google.com/forum/?hl=en#!forum/jhipster-dev).
+Internal team discussions happen in the following channels :
+- The [jhipster-dev mailing list](https://groups.google.com/forum/?hl=en#!forum/jhipster-dev)
+- The [jhipster-dev-team Gitter chat](https://gitter.im/jhipster/jhipster-dev-team)
+
+Those discussion channels are publicly viewable, as everything we do in JHipster is public, but only the board of developers can participate. The mailing list archives can be found on the [Google groups page](https://groups.google.com/forum/?hl=en#!forum/jhipster-dev) and the [chat archives](https://gitter.im/jhipster/jhipster-dev-team/archives/all) are available on Gitter.
 
 # How to join the board of developers?
 


### PR DESCRIPTION
For transparency as some discussions do happen there and as the chat archives are publicly viewable.