### PR TITLE
fix deprecated config key

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,7 +4,7 @@ exclude: [node_modules, bower_components, vendor]
 url: https://www.jhipster.tech
 kramdown:
   input: GFM
-gems:
+plugins:
   - jekyll-redirect-from
 whitelist:
   - jekyll-redirect-from


### PR DESCRIPTION
When launching the site locally with `docker-compose`, it outputs a deprecation warning:

       Deprecation: The 'gems' configuration option has been renamed to 'plugins'. Please update your config file accordingly.