### PR TITLE
Removed "Twitter" from "Twitter Bootstrap"

### DIFF
--- a/presentation/index.html
+++ b/presentation/index.html
@@ -170,7 +170,7 @@
                         </ul>
                     </section>
                     <section>
-                        <h1>Twitter Bootstrap</h1>
+                        <h1>Bootstrap</h1>
                         <h3>Great CSS/JavaScript framework for responsive Web apps</h3>
                         <ul>
                             <li>CSS and HTML elements for all common usages</li>


### PR DESCRIPTION
*Twitter Bootstrap* has been abandoned a long time ago (v2); according to their [Brand Guidelines](https://v4-alpha.getbootstrap.com/about/brand/#name), the only correct way to name it is ***Bootstrap***.