### PR TITLE
Fix a typo on the Profiles page

### DIFF
--- a/pages/profiles.md
+++ b/pages/profiles.md
@@ -57,7 +57,7 @@ When you run your production application from a WAR file, the default is to use 
 
 ## Spring profiles switches
 
-JHipster comes with three additional profiles used as switches:
+JHipster comes with two additional profiles used as switches:
 
 *   `swagger` to enable swagger
 *   `no-liquibase` to disable liquibase


### PR DESCRIPTION
Tiny fix, Profiles page incorrectly claims there are three additional profiles but there are only two now that "shell" is deprecated