### PR TITLE
note kubernetes version requirement

### DIFF
--- a/pages/kubernetes.md
+++ b/pages/kubernetes.md
@@ -19,6 +19,7 @@ This sub-generator allows deployment of your JHipster application to [Kubernetes
 ## Limitations
 
 - Cassandra is not supported yet
+- Kubernetes v1.9+ is required
 
 ## Pre-requisites
 


### PR DESCRIPTION
The Kubernetes version required is v1.9+ because we use `apiVersion: apps/v1` ([here](https://github.com/jhipster/generator-jhipster/blob/dc20f4801f4aea3328debbd78804c47a54d1006e/generators/kubernetes/templates/deployment.yml.ejs#L19)).  Google Cloud's Kubernetes engine defaults to `v1.8.10-gke.0` so it fails by default:

    Deployment in version "v1" cannot be handled as a Deployment:
    no kind "Deployment" is registered for version "apps/v1"

You can use older K8s versions with `apiVersion: apps/v1beta1`