### PR TITLE
Fix typo `security.user.password` vs `spring.security.user.password`

### DIFF
--- a/pages/jhipster-registry.md
+++ b/pages/jhipster-registry.md
@@ -179,5 +179,5 @@ Applications also connect to the JHipster Registry using that same "admin" user,
 
 In order to secure your JHipster Registry:
 
-- You must change the default "admin" password. This password is set using the standard Spring Boot property `security.user.password`, so you can use the usual Spring Boot mechanisms to modify it: you could modify the project's `application-*.yml` files, or add a `SPRING_SECURITY_USER_PASSWORD` environment variable. The [Docker Compose sub-generator]({{ site.url }}/docker-compose/) uses the environment variable method.
+- You must change the default "admin" password. This password is set using the standard Spring Boot property `spring.security.user.password`, so you can use the usual Spring Boot mechanisms to modify it: you could modify the project's `application-*.yml` files, or add a `SPRING_SECURITY_USER_PASSWORD` environment variable. The [Docker Compose sub-generator]({{ site.url }}/docker-compose/) uses the environment variable method.
 - As your applications will connect to the registry using HTTP, it is very important to secure that connection channel. There are many ways to do it, and the easiest one is probably to use HTTPS.


### PR DESCRIPTION
A minor typo. 