### PR TITLE
add note about gatling 2 compatibility

### DIFF
--- a/pages/running_tests.md
+++ b/pages/running_tests.md
@@ -77,7 +77,7 @@ Performance tests are done with [Gatling](http://gatling.io/), and are located i
 
 To run Gatling tests, you must first install Gatling: please go to the [Gatling download page](https://gatling.io/download/) and follow the instructions there. Please note we do not allow to run Gatling from Maven or Gradle, as it causes some classpath issues with other plugins (mainly because of the use of Scala).
 
-**NOTE** We currenlty only support Gatling 2.x. So make sure you install Gatling 2.x. You can download the latest 2.x version directly from [maven central](https://repo1.maven.org/maven2/io/gatling/highcharts/gatling-charts-highcharts-bundle/2.3.1/gatling-charts-highcharts-bundle-2.3.1-bundle.zip).
+**NOTE** We currently support Gatling 2.x only. You can download the latest 2.x version directly from [maven central](https://repo1.maven.org/maven2/io/gatling/highcharts/gatling-charts-highcharts-bundle/2.3.1/gatling-charts-highcharts-bundle-2.3.1-bundle.zip).
 
 **Warning!** At the moment, those tests do not take into account the validation rules you may have enforced on your entities. Also tests for creating entities that have a required relationship with another entity will fail out of the box. You will anyway need to change those tests, according to your business rules, so here are few tips to improve your tests:
 

--- a/pages/running_tests.md
+++ b/pages/running_tests.md
@@ -75,7 +75,9 @@ Those tests can be run using `npm run e2e`.
 
 Performance tests are done with [Gatling](http://gatling.io/), and are located in the `src/test/gatling` folder. They are generated for each entity, and allows to test each of them with a lot of concurrent user requests.
 
-To run Gatling tests, you must first install Gatling: please go to the [Gatling download page](https://gatling.io/download/) and follow the instructions there. Please note we do not allow to run Gatling from Maven, as it causes some classpath issues with other plugins (mainly because of the use of Scala).
+To run Gatling tests, you must first install Gatling: please go to the [Gatling download page](https://gatling.io/download/) and follow the instructions there. Please note we do not allow to run Gatling from Maven or Gradle, as it causes some classpath issues with other plugins (mainly because of the use of Scala).
+
+**NOTE** We currenlty only support Gatling 2.x. So make sure you install Gatling 2.x. You can download the latest 2.x version directly from [maven central](https://repo1.maven.org/maven2/io/gatling/highcharts/gatling-charts-highcharts-bundle/2.3.1/gatling-charts-highcharts-bundle-2.3.1-bundle.zip).
 
 **Warning!** At the moment, those tests do not take into account the validation rules you may have enforced on your entities. Also tests for creating entities that have a required relationship with another entity will fail out of the box. You will anyway need to change those tests, according to your business rules, so here are few tips to improve your tests:
 


### PR DESCRIPTION
The current gatling documentation pushes gatling 3. I could not find a download link to the current 2.x release on their homepage anymore, so we should make clear we currently support only 2.x and provide a download link via maven central. 

See https://github.com/jhipster/generator-jhipster/issues/8552#issuecomment-429716324