### PR TITLE
Conference updates

### DIFF
--- a/index.html
+++ b/index.html
@@ -157,14 +157,18 @@ sitemap:
                         </div>
                     </div>
                 </div>
-                <div class="col-md-offset-2 col-sm-12 col-md-4">
+                <div class="col-md-12 text-center">
                     <p>
                         <strong>Thank you to all our backers!</strong>
                     </p>
-                    <!-- shown in large screens only -->
-                    <object class="visible-sm visible-md visible-lg" data="https://opencollective.com/generator-jhipster/tiers/backer.svg?avatarHeight=40&width=760" type="image/svg+xml"></object>
-                    <!-- shown in mobile screens only -->
-                    <object class="visible-xs" data="https://opencollective.com/generator-jhipster/tiers/backer.svg?avatarHeight=40&width=330" type="image/svg+xml"></object>
+                    <div class="row">
+                        <div class="col-md-offset-2 col-sm-12 col-md-4">
+                            <!-- shown in large screens only -->
+                            <object class="visible-sm visible-md visible-lg" data="https://opencollective.com/generator-jhipster/tiers/backer.svg?avatarHeight=40&width=760" type="image/svg+xml"></object>
+                            <!-- shown in mobile screens only -->
+                            <object class="visible-xs" data="https://opencollective.com/generator-jhipster/tiers/backer.svg?avatarHeight=40&width=330" type="image/svg+xml"></object>
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -157,7 +157,7 @@ sitemap:
                         </div>
                     </div>
                 </div>
-                <div class="col-md-12 text-center">
+                <div class="col-md-offset-2 col-sm-12 col-md-4">
                     <p>
                         <strong>Thank you to all our backers!</strong>
                     </p>
@@ -197,12 +197,14 @@ sitemap:
                         </ul>
                         <h3>Events</h3>
                           <ul>
-                              <li><b>October 10th, 2018:</b> at <a href="https://www.meetup.com/fr-FR/AXA-Meetup-PARIS/events/254444584/">Axa meetup in Paris, France</a>, Julien Dubois will do a JHipster presentation and live coding session. <a href="https://www.meetup.com/fr-FR/AXA-Meetup-PARIS/events/254444584/">Register here!</a></li>
-                              <li><b>October 11th, 2018:</b> at <a href="http://www.meetup.com/fr/JHipster-User-Group/">JHipster meetup in Paris, France</a>, Bruno Borges (Microsoft) will present a session on deploying JHipster applications on Microsoft Azure. <a href="https://www.meetup.com/fr-FR/JHipster-User-Group/events/254371421/">Register here!</a></li>
+                              <li><b>October 18th, 2018:</b> at <a href="http://connect.tech/">Connect.Tech</a>, Matt Raible will present on microservices and JHipster.</li>
                               <li><b>October 18-19th, 2018:</b> at <a href="https://heapcon.io">Heapcon Belgrade, Serbia</a>, Deepu K Sasidharan will present a JHipster session.</li>
                               <li><b>October 20th, 2018:</b> at <a href="http://www.changecon.com">Changecon Zagreb, Croatia</a>, Deepu K Sasidharan will present a JHipster session.</li>
+                              <li><b>October 22nd, 2018:</b> at <a href="https://www.oracle.com/code-one/index.html">CodeOne</a>, Matt Raible and Sendil Kumar both have <a href="https://oracle.rainfocus.com/widget/oracle/oow18/catalogcodeone18?search=jhipster">JHipster presentations</a>.</li>
                               <li><b>October 29-31th, 2018:</b> at <a href="https://voxxeddays.com/microservices/">Voxxed Days microservices, in Paris, France</a>, Julien Dubois, Pascal Grimaud and Pierre Besson will do a 1-day workshop on developing microservices with JHipster.</li>
                               <li><b>November 12-16th, 2018:</b> at <a href="https://devoxx.be/">Devoxx Belgium in Antwerp, Belgium</a>, Julien Dubois and Deepu K Sasidharan will present a JHipster 5 session.</li>
+                              <li><b>November 15th, 2018:</b> at <a href="https://www.meetup.com/ChicagoJUG/">Chicago JUG</a>, Matt Raible will present on microservices and JHipster.</li>
+                              <li><b>November 15th, 2018:</b> at <a href="https://therichwebexperience.com/conference/clearwater/2018/12/session?id=42403">The Rich Web Experience</a>, Matt Raible will present on microservices and JHipste.</li>
                               <li><b>Looking for a meetup near you?</b> <a href="{{ site.url }}/meetups/">Go to our new Meetup list</a> and join one of our local groups!</li>
                           </ul>
                     </div>


### PR DESCRIPTION
I also centered the "backers" area. Here's what it looks like currently:

<img width="1172" alt="screen shot 2018-10-15 at 3 55 49 pm" src="https://user-images.githubusercontent.com/17892/46980766-e7f20280-d092-11e8-9512-a59563d54171.png">

Here's what it looks like after the changes I made:

<img width="1132" alt="screen shot 2018-10-15 at 4 00 05 pm" src="https://user-images.githubusercontent.com/17892/46980953-7bc3ce80-d093-11e8-886e-6004474e1633.png">

