### PR TITLE
Align doc with code for DTOs

### DIFF
--- a/pages/using_dtos.md
+++ b/pages/using_dtos.md
@@ -9,9 +9,7 @@ sitemap:
     lastmod: 2015-05-28T23:41:00-00:00
 ---
 
-# <i class="fa fa-briefcase"></i> [BETA] Using DTOs
-
-__WARNING!__ This is a new feature, of <b>BETA</b> quality. Use it at your own risk! Feedback is highly welcome!
+# <i class="fa fa-briefcase"></i> Using DTOs
 
 ## Introduction
 


### PR DESCRIPTION
Documentation and code are not synced.
Indeed beta tag for DTO has been removed in the generator (https://github.com/jhipster/generator-jhipster/pull/8001/files) but still present in the documentation.

_Note: I played a bit with DTOs since few days and I found other parts of the doc not up to date or some behaviours need to be clarified. I will try to PR or add issues to discuss it._

_Moreover, I used DTOs in an old jhipster version (v3.12.2) and I found it simpler than today. I will add an issue in the generator to expose my point of view and what I propose to improve this feature._