### PR TITLE
Fix typo and wording regarding data replication

### DIFF
--- a/pages/using_elasticsearch.md
+++ b/pages/using_elasticsearch.md
@@ -16,13 +16,13 @@ Elasticsearch is an option that adds search capabilities on top of your database
 This option has some limitations:
 
 *   It only works with SQL databases and MongoDB. Cassandra and Couchbase support will be added in the future (help is welcome!).
-*   There is no consistency between your database and Elasticsearch, so you might have out-of-sync data. This is normal, as Elasticsearch is not a real database. As a result, you will probably need to write some specific code to synchronize your data, for example using the Spring `@Scheduled` annotation, to run every evening.
+*   There is no automatic replication mechanism between your database and Elasticsearch, so you might have out-of-sync data. As a result, you will probably need to write some specific code to synchronize your data, for example using the Spring `@Scheduled` annotation, to run every evening.
     *   This also means if your database is changed outside of your application, your search indexes will be out-of-sync.  The [Elasticsearch Reindexer](https://www.jhipster.tech/modules/marketplace/#/details/generator-jhipster-elasticsearch-reindexer) JHipster module can help in these situations.
 
 When the Elasticsearch option is selected:
 
 *   Spring Data Elasticsearch is used, with the help of [Spring Data Jest](https://github.com/VanRoy/spring-data-jest). Spring Data Jest which allows communication with Elasticsearch's REST API. It disables Spring Boot's autoconfiguration and uses its own instead.
-*   The "repository" package has new subpackage, called "search", that holds all ElastiSearch repositories.
+*   The "repository" package has new subpackage, called "search", that holds all Elasticsearch repositories.
 *   The "User" entity gets indexed in Elasticsearch, and you can query is using the `/api/_search/users/:query` REST endpoint.
 *   When the [entity sub-generator]({{ site.url }}/creating-an-entity/) is used, the generated entity gets automatically indexed by Elasticsearch, and is used in the REST endpoint. Search capabilities are also added to the Angular/React user interface, so you can search your entity in the main CRUD screen.
 


### PR DESCRIPTION
Elasticsearch defines itself as document oriented database, thus the sentence "This is normal, as Elasticsearch is not a real database" has been removed. Instead, it is clarified that there's no automatic replication mechanism.

Relevant link: [Elasticsearch as a NoSQL Database](https://www.elastic.co/blog/found-elasticsearch-as-nosql)