### PR TITLE
improve random number

### DIFF
--- a/presentation/plugin/multiplex/index.js
+++ b/presentation/plugin/multiplex/index.js
@@ -36,7 +36,8 @@ app.get("/", function(req, res) {
 
 app.get("/token", function(req,res) {
 	var ts = new Date().getTime();
-	var rand = Math.floor(Math.random()*9999999);
+	var rand = new Uint32Array(1);
+	window.crypto.getRandomValues(array)
 	var secret = ts.toString() + rand.toString();
 	res.send({secret: secret, socketId: createHash(secret)});
 });


### PR DESCRIPTION
I've noticed `Math.random()` used in a sensitive context. However, its values are not safe against prediction, so if I understand the context correctly, it's preferable to use `Window.crypto` instead.

Full disclosure: I noticed this using [LGTM.com](https://lgtm.com/projects/g/jhipster/jhipster.github.io/alerts/?mode=list&tag=security), a code analysis platform which I also work for.