### PR TITLE
Added a section to run as a service

### DIFF
--- a/pages/production.md
+++ b/pages/production.md
@@ -102,7 +102,7 @@ Secure your application with:
 `chown jhuser:jhuser jhipster-0.0.1-SNAPSHOT.war
 sudo chattr +i your-app.jar`
 
-being jhuser the non root os account that will run the application, and you will be able to run like that:
+Considering `jhuser` a non-root OS account that will run the application, then the application can be run this way:
 
 `service jhipster start|stop|restart`
 

--- a/pages/production.md
+++ b/pages/production.md
@@ -97,11 +97,16 @@ Next, setup your init.d with:
 
 `ln -s jhipster-0.0.1-SNAPSHOT.war /etc/init.d/jhipster`
 
-and you will be able to run 
+Secure your application with:
+
+`chown jhuser:jhuser jhipster-0.0.1-SNAPSHOT.war
+sudo chattr +i your-app.jar`
+
+being jhuser the non root os account that will run the application, and you will be able to run like that:
 
 `service jhipster start|stop|restart`
 
-There are many other options that you can find in [Spring Boot documentation](https://docs.spring.io/spring-boot/docs/current/reference/html/deployment-install.html), including Windows service.
+There are many other options that you can find in [Spring Boot documentation](https://docs.spring.io/spring-boot/docs/current/reference/html/deployment-install.html), including more security steps and Windows service.
 
 ## <a name="performance"></a> Performance optimizations
 

--- a/pages/production.md
+++ b/pages/production.md
@@ -85,6 +85,24 @@ JHipster has first-class support for Docker: it is very easy to bundle your exec
 
 To learn how to package your application with Docker, please read our [Docker Compose documentation]({{ site.url }}/docker-compose/).
 
+### Run as a service
+
+It is also possible to run the war as a Linux service, and you may want to force in your `pom.xml` file before packaging. To do it, add the following property inside `<configuration>` of `spring-boot-maven-plugin` plugin. 
+
+                            <embeddedLaunchScriptProperties>
+                                <mode>service</mode>
+                            </embeddedLaunchScriptProperties>
+
+Next, setup your init.d with: 
+
+`ln -s jhipster-0.0.1-SNAPSHOT.war /etc/init.d/jhipster`
+
+and you will be able to run 
+
+`service jhipster start|stop|restart`
+
+There are many other options that you can find in [Spring Boot documentation](https://docs.spring.io/spring-boot/docs/current/reference/html/deployment-install.html), including Windows service.
+
 ## <a name="performance"></a> Performance optimizations
 
 ### Cache tuning


### PR DESCRIPTION
Although there is the possibility to run directly, it starts in foreground. It normally runs in auto mode, but added a way to explicit generate the package with service mode and pointing to spring docs.