### PR TITLE
Add official blueprints supports + Vue.js doc

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -250,6 +250,7 @@
                                             <li {% if '/managing-server-errors/' == page.url %}class="active" {% endif %}><a href="{{ site.url }}/managing-server-errors/"><i class="fa fa-fw fa-fire-extinguisher"></i> Managing server errors</a></li>
                                             <li {% if '/using-angular/' == page.url %}class="active" {% endif %}><a href="{{ site.url }}/using-angular/"><i class="fa fa-fw fa-html5"></i> Using Angular</a></li>
                                             <li {% if '/using-react/' == page.url %}class="active" {% endif %}><a href="{{ site.url }}/using-react/"><i class="fa fa-fw fa-html5"></i> Using React</a></li>
+                                            <li {% if '/using-vue/' == page.url %}class="active" {% endif %}><a href="{{ site.url }}/using-vue/"><i class="fa fa-fw fa-html5"></i> Using Vue</a></li>
                                             <li {% if '/customizing-bootstrap-4/' == page.url %}class="active" {% endif %}><a href="{{ site.url }}/customizing-bootstrap-4/"><i class="fa fa-fw fa-css3"></i> Customizing Bootstrap 4</a></li>
                                             <li {% if '/tls/' == page.url %}class="active" {% endif %}><a href="{{ site.url }}/tls/"><i class="fa fa-fw fa-lock"></i> Using TLS and HTTP/2</a></li>
                                         </ul>
@@ -295,6 +296,7 @@
                                 <div id="dropdown-10" class="panel-collapse collapse" style="height: 0px;">
                                     <div class="panel-body">
                                         <ul class="nav navbar-nav">
+                                            <li {% if '/modules/official-blueprints/' == page.url %}class="active" {% endif %}><a href="{{ site.url }}/modules/official-blueprints/"><i class="fa fa-fw fa-star"></i> Official blueprints</a></li>
                                             <li {% if '/modules/marketplace/' == page.url %}class="active" {% endif %}><a href="{{ site.url }}/modules/marketplace/"><i class="fa fa-fw fa-shopping-cart"></i> Marketplace</a></li>
                                             <li {% if '/modules/creating-a-module/' == page.url %}class="active" {% endif %}><a href="{{ site.url }}/modules/creating-a-module/"><i class="fa fa-fw fa-cube"></i> Creating a module</a></li>
                                             <li {% if '/modules/creating-a-blueprint/' == page.url %}class="active" {% endif %}><a href="{{ site.url }}/modules/creating-a-blueprint/"><i class="fa fa-fw fa-cube"></i> Creating a blueprint</a></li>

--- a/images/logo/svg/vue.svg
+++ b/images/logo/svg/vue.svg
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg version="1.1" viewBox="0 0 261.76 226.69" xmlns="http://www.w3.org/2000/svg"><g transform="matrix(1.3333 0 0 -1.3333 -76.311 313.34)"><g transform="translate(178.06 235.01)"><path d="m0 0-22.669-39.264-22.669 39.264h-75.491l98.16-170.02 98.16 170.02z" fill="#41b883"/></g><g transform="translate(178.06 235.01)"><path d="m0 0-22.669-39.264-22.669 39.264h-36.227l58.896-102.01 58.896 102.01z" fill="#34495e"/></g></g></svg>

--- a/index.html
+++ b/index.html
@@ -268,12 +268,14 @@ sitemap:
                         <a href="https://angular.io/" target="_blank"><img src="images/logo/svg/angular.svg" class="project-icon img-responsive"></a><br class="visible-xs">
                         <i class="fa fa-4x">/</i>
                         <a href="https://reactjs.org/" target="_blank"><img src="images/logo/svg/react.svg" class="project-icon img-responsive"></a><br class="visible-xs">
+                        <i class="fa fa-4x">/</i>
+                        <a href="https://vuejs.org/" target="_blank"><img src="images/logo/svg/vue.svg" class="project-icon img-responsive"></a><br class="visible-xs">
                         <i class="fa fa-4x">=</i>
                         <a href="/"><img id="hipster-head" src="images/logo/jhipster_family_member_0_head.svg" class="project-icon img-responsive"></a>
                     </div>
                     <p class="lead">
                       JHipster is a development platform to generate, develop and deploy
-                      <a class="dark" href="http://projects.spring.io/spring-boot/" target="_blank">Spring Boot</a> + <a class="dark" href="https://angular.io/" target="_blank">Angular</a>/<a class="dark" href="https://reactjs.org/" target="_blank">React</a>
+                      <a class="dark" href="http://projects.spring.io/spring-boot/" target="_blank">Spring Boot</a> + <a class="dark" href="https://angular.io/" target="_blank">Angular</a> / <a class="dark" href="https://reactjs.org/" target="_blank">React</a> / <a class="dark" href="https://vuejs.org/" target="_blank">Vue</a>
                       Web applications and Spring microservices. <br>
                     </p>
                 </span>
@@ -300,6 +302,18 @@ sitemap:
                     <p>
                         You can checkout a sample generated React application
                         <a href="https://github.com/jhipster/jhipster-sample-app-react" target="_blank">here</a>.
+                    </p>
+                    <p>
+                        You can checkout a sample generated Vue.js application
+                        <a href="https://github.com/jhipster/jhipster-sample-app-vuejs" target="_blank">here</a>.
+                    </p>
+                    <p>
+                        You can checkout a sample generated Kotlin application
+                        <a href="https://github.com/jhipster/jhipster-sample-app-kotlin" target="_blank">here</a>.
+                    </p>
+                    <p>
+                        You can checkout a sample generated .Net application
+                        <a href="https://github.com/jhipster/jhipster-net-sample-app-template" target="_blank">here</a>.
                     </p>
                     <p>
                         JHipster is Open Source, and all development is done on
@@ -424,6 +438,10 @@ sitemap:
                 <li class="clip img-circle new">
                     <img src="images/logo/svg/react.svg" />
                     <span class="title_sub_tech">React</span>
+                </li>
+                <li class="clip img-circle new">
+                    <img src="images/logo/svg/vue.svg" />
+                    <span class="title_sub_tech">Vue</span>
                 </li>
                 <li class="clip img-circle new">
                     <img src="images/logo/svg/redux.svg" />

--- a/modules/official-blueprints.md
+++ b/modules/official-blueprints.md
@@ -1,0 +1,37 @@
+---
+layout: default
+title: Official blueprints
+permalink: /modules/official-blueprints/
+redirect_from:
+  - /official-blueprints.html
+  - /modules/official-blueprints.html
+sitemap:
+    priority: 0.7
+    lastmod: 2019-03-29T18:40:00-00:00
+---
+
+# <i class="fa fa-star"></i> Officially supported blueprints
+
+JHipster supports several official blueprints. These blueprints have two main goals:
+
+* Enhance JHipster with new features using different languages and/or support
+* Demonstrate how the main generator behavior can be modified to fit anyone needs
+
+## Kotlin
+
+First official blueprint, it replaces most of Java back-end code with Kotlin. Source code and documentation could be found here: [repository](https://github.com/jhipster/jhipster-kotlin).
+
+Stream lead is: [Sendil Kumar](https://github.com/sendilkumarn).
+
+## Vue.js
+
+Second official blueprint, it replaces the whole front-end logic with Vue.js. Source code and documentation could be found here: [repository](https://github.com/jhipster/jhipster-vuejs).
+
+Stream lead is: [Sahbi Ktifa](https://github.com/sahbi-ktifa).
+
+## .Net
+
+Latest official blueprint, this is the first attempt to leave the Java environment and join .Net world. Source code and documentation could be found here: [repository](https://github.com/jhipster/jhipster-dotnetcore).
+
+Stream lead is: [Daniel Petisme](https://github.com/danielpetisme).
+

--- a/modules/official-blueprints.md
+++ b/modules/official-blueprints.md
@@ -15,7 +15,7 @@ sitemap:
 JHipster supports several official blueprints. These blueprints have two main goals:
 
 * Enhance JHipster with new features using different languages and/or support
-* Demonstrate how the main generator behavior can be modified to fit anyone needs
+* Demonstrate how the main generator behavior can be modified to fit anyone's needs
 
 ## Kotlin
 

--- a/pages/creating_an_entity.md
+++ b/pages/creating_an_entity.md
@@ -111,7 +111,7 @@ Validation can be set up for each field. Depending on the field type, different 
 
 Validation will be automatically generated on:
 
-*   the HTML views, using the Angular or React validation mechanism
+*   the HTML views, using the Angular or React or Vue validation mechanism
 *   the Java domain objects, using [Bean Validation](http://beanvalidation.org/)
 
 Bean validation will then be used to automatically validate domain objects when they are used in:

--- a/pages/running_tests.md
+++ b/pages/running_tests.md
@@ -22,7 +22,7 @@ Optionally, JHipster can also generate:
 
 *   Performance tests with [Gatling.](http://gatling.io/)
 *   Behaviour-driven tests with [Cucumber](https://cucumber.io/)
-*   Angular/React integration tests with [Protractor](https://angular.github.io/protractor/#/).
+*   Angular/React/Vue integration tests with [Protractor](https://angular.github.io/protractor/#/).
 
 We have two goals in generating those tests:
 

--- a/pages/tech_stack.md
+++ b/pages/tech_stack.md
@@ -15,7 +15,7 @@ sitemap:
 
 Single Web page application:
 
-*   [Angular](https://angular.io/) or [React](https://reactjs.org/)
+*   [Angular](https://angular.io/) or [React](https://reactjs.org/) or [Vue](https://vuejs.org/)
 *   Responsive Web Design with [Twitter Bootstrap](http://getbootstrap.com/)
 *   [HTML5 Boilerplate](http://html5boilerplate.com/)
 *   Compatible with modern browsers (Chrome, FireFox, Microsoft Edge...)

--- a/pages/tls.md
+++ b/pages/tls.md
@@ -33,7 +33,7 @@ The application will be available on `https://localhost:8080/`.
 
 As the certificate is self-signed, your browser will issue a warning, and you will need to ignore it (or import it) in order to access the application.
 
-## Using TLS and HTTP/2 with Angular or React
+## Using TLS and HTTP/2 with Angular or React or Vue.js
 
 Instead of using `npm start` in order to run the front-end (with Webpack and BrowserSync), just run `npm run start-tls`, and it will connect to the back-end running on `https://localhost:8080/`.
 

--- a/pages/using-vue.md
+++ b/pages/using-vue.md
@@ -1,0 +1,142 @@
+---
+layout: default
+title: Using Vue
+permalink: /using-vue/
+sitemap:
+    priority: 0.7
+    lastmod: 2019-03-27T23:41:00-00:00
+---
+
+# <i class="fa fa-html5"></i> Using Vue
+This section refers to the JavaScript library **Vue.js**.
+
+## Project Structure
+
+The JHipster client code can be found under `src/main/webapp`.
+
+Please read this guide first if you have any question on our application structure, file names, TypeScript conventions...
+
+Note that we use TypeScript in our generated Vue application following [vue-class-component](https://github.com/vuejs/vue-class-component) style and guidelines.
+
+For Vue routes we follow a dash cased naming convention so that the URLs are clean and consistent.
+When you generate an entity the route names, route URLs and REST API endpoint URLs are generated according to this convention, also entity names are automatically pluralized where required.
+
+Here is the main project structure:
+
+```
+webapp
+├── app                             - Your application
+│   ├── account                     - Account related components
+│   ├── admin                       - Administration related components
+│   ├── core                        - Main components such as Home, navbar, ...
+│   ├── entities                    - Generated entities
+│   ├── locale                      - I18n / translation related components
+│   ├── router                      - Routing configuration
+│   ├── shared                      - Shared elements such as your config, models and util classes
+│   ├── app.component.ts            - The application main class
+│   ├── app.vue                     - The application main SFC component
+│   ├── constants.ts                - Global application constants
+│   ├── main.ts                     - Index script, application entrypoint
+│   └── shims-vue.d.ts
+├── content                         - Contains your static files such as images and fonts
+├── i18n                            - Translation files
+├── swagger-ui                      - Swagger UI front-end
+├── 404.html                        - 404 page
+├── favicon.ico                     - Fav icon
+├── index.html                      - Index page
+├── manifest.webapp                 - Application manifest
+└── robots.txt                      - Configuration for bots and Web crawlers
+```
+
+Using the [entity sub-generator]({{ site.url }}/creating-an-entity/) to create a new entity called `Foo` generates the following front-end files under `src/main/webapp`:
+
+```
+webapp
+├── app                                        
+│   ├── entities
+│   │   └── foo                           - CRUD front-end for the Foo entity
+│   │       ├── foo-details.vue           - Details SFC component
+│   │       ├── foo-detail.component.ts   - Details page component
+│   │       ├── foo-update.vue            - Creation / Update SFC component
+│   │       ├── foo-update.component.ts   - Creation / Update component class
+│   │       ├── foo.vue                   - Entity main SFC component
+│   │       ├── foo.component.ts          - Entity main component class
+│   │       └── foo.service.ts            - Foo entity service
+│   ├── router
+│   │   └── index.ts                      - Entity main routes configuration
+│   └── shared
+│       └── model
+│           └── foo.model.ts              - Entity model class
+└── i18n                                  - Translation files
+     ├── en                               - English translations
+     │   ├── foo.json                     - English translation of Foo name, fields, ...
+     └── fr                               - French translations
+         └── foo.json                     - French translation of Foo name, fields, ...
+```
+
+Please note that the default language translations would be based on what you have choosen during app generation. 'en' and 'fr' are shown here only for demonstration.
+
+## Store using VuexStore
+
+Application will use a store [VuexStore](https://vuex.vuejs.org/guide/state.html) to maintain state within the application.
+
+This store is configured at startup in `app/config/config.ts:initVueXStore`. Please refer to Vuex documentation to add new states or mutations.
+
+The application will use the store to maintain:
+
+* User authentication information
+* Language and translation 
+* Notification and alert information
+* Active profiles data
+
+## Authorizations
+
+JHipster uses the [Vue router](https://router.vuejs.org/) to organize the differents parts of your application.
+
+When it comes to routes that require authentication, the meta `authorities` is used on desired route. This component will simply prevent any unauthenticated or unauthorized user from accessing a route.
+
+Here is an example of PrivateRoute usage:
+
+``` typescript
+const Routes = () => [{
+      path: '/public',
+      name: 'public',
+      component: Public
+    },
+    {
+      path: '/private',
+      name: 'Private',
+      component: Private,
+      meta: { authorities: ['ROLE_USER'] }
+    }];
+```
+
+As you can see, unauthenticated user can access `/public` but accessing `/private` requires at least to be logged in.
+
+Please note that the interceptor uses the `$store.getters.authenticated` store value to know if the user is authenticated.
+
+## Validation system
+
+In order to perform form validation, we use [Vuelidate](https://vuelidate.netlify.com/) library. Besides adding validation constraints, several filters are already furnished and enable a full validation on form. Custom validation can obviously be added as such:
+
+```typescript
+import { required } from 'vuelidate/lib/validators';
+
+const mustBeCool = (value) => value.indexOf('cool') >= 0;
+const validations = {
+  foo: {
+    required,
+    mustBeCool
+  }
+};
+@Component({
+  validations
+})
+export default class FooComponent extends Vue {
+  foo: string = null;
+}
+```
+
+## Bootswatch theme
+
+Theming Bootstrap can be done directly using [Bootswatch](https://bootswatch.com) themes. We now provide questions during generation to pick one of the many themes served by Bootswatch.


### PR DESCRIPTION
Add multiple sections, including:
* Vue.js documentation
* Officially supported blueprints

Mentions of Vue.js when needed

PS: We should wait for sample-app repositories to be created first.

![2019-03-28 16 08 30](https://user-images.githubusercontent.com/7074827/55168849-e6655400-5173-11e9-837c-748246fbf1e8.gif)

![2019-03-28 15 59 55](https://user-images.githubusercontent.com/7074827/55168218-b7021780-5172-11e9-8a76-b0c154317ba3.gif)
