### PR TITLE
Hide generator-jhipster-{module|blueprint} from marketplace

### DIFF
--- a/modules/marketplace/data/modules-config.json
+++ b/modules/marketplace/data/modules-config.json
@@ -3,6 +3,8 @@
         "generator-jhipster-fortune" : true
     },
     "blacklistedModules": {
+        "generator-jhipster-blueprint" : true,
+        "generator-jhipster-module" : true,
         "generator-jhipster-webservice" : true,
         "generator-jhipster-react" : true,
         "generator-jhipster-material" : true


### PR DESCRIPTION
They're not module or blueprint per say, they're generators of module and blueprint