### PR TITLE
Hide deprecated or unofficial vuejs modules & blueprints

### DIFF
--- a/modules/marketplace/data/modules-config.json
+++ b/modules/marketplace/data/modules-config.json
@@ -5,6 +5,9 @@
     "blacklistedModules": {
         "generator-jhipster-webservice" : true,
         "generator-jhipster-react" : true,
-        "generator-jhipster-material" : true
+        "generator-jhipster-material" : true,
+        "jhipster-vuejs" : true,
+        "generator-jhipster-vuejs2" : true,
+        "generator-jhipster-vuejsx" : true
     }
 }


### PR DESCRIPTION
- `jhipster-vuejs`: former name of our official blueprint
- `generator-jhipster-vuejsx`: deprecated (in favor of `generator-jhipster-vuejs2`)
- `generator-jhipster-vuejs2`: module that depends on a fork of `generator-jhipster`