### PR TITLE
Fix missing html <p> tags

### DIFF
--- a/pages/docker_compose.md
+++ b/pages/docker_compose.md
@@ -105,8 +105,10 @@ However in a local environment, this might fail your build if jib cannot access 
 <p>
 With Maven, type: <pre>./mvnw -Pprod package verify jib:dockerBuild --offline</pre>
 With Gradle, type: <pre>./gradlew -Pprod bootJar jibDockerBuild --offline</pre>
-
+</p>
+<p>
 Note that jib is currently unable to pull a local Docker image from the Docker daemon. Progress on this issue is tracked at [GoogleContainerTools/jib/issues/1468](https://github.com/GoogleContainerTools/jib/issues/1468).
+</p>
 </div>
 
 To run this image, use the Docker Compose configuration located in the `src/main/docker` folder of your application:


### PR DESCRIPTION
The docker-compose is not rendered properly due to missing tags.

<img width="1363" alt="Capture d’écran 2019-05-29 à 00 48 41" src="https://user-images.githubusercontent.com/37835668/58517510-ec93a300-81ab-11e9-90f6-2b6945cdd091.png">
