### PR TITLE
Improve releases page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,8 +7,10 @@ kramdown:
   input: GFM
 gems:
   - jekyll-redirect-from
+  - jemoji
 whitelist:
   - jekyll-redirect-from
+  - jemoji
 defaults:
     scope:
       path: "" # an empty string here means all files in the project

--- a/pages/releases.md
+++ b/pages/releases.md
@@ -14,5 +14,15 @@ sitemap:
 To get the latest JHipster news, please follow us on Twitter: [@java_hipster](https://twitter.com/java_hipster)
 
 {% for post in site.posts %}
-*   [{{ post.title }}]({{ post.url }})
+  {% assign split_post_title = post.title | split: "Release " %}
+  {% assign split_post_version = split_post_title[1] | split: "." %}
+  {% assign post_minor_version = split_post_version[1] %}
+  {% assign post_patch_version = split_post_version[2] %}
+  {% assign split_post_date = post.date | split: " " %}
+  {% assign post_date = split_post_date.first %}
+  {% if post_minor_version == '0' and post_patch_version == '0' %}
+  *   **[{{ post.title }}]({{ post.url }}) ({{ post_date }})** :rocket:
+  {% else %}
+  *   [{{ post.title }}]({{ post.url }})
+  {% endif %}
 {% endfor %}


### PR DESCRIPTION
It's a proposal to improve the releases page.

I added on the major release:
* date
* bold
* emoji rocket

What do you think ? 

<img width="1271" alt="Capture d’écran 2019-05-29 à 16 13 28" src="https://user-images.githubusercontent.com/9989211/58564197-ceba5280-822c-11e9-8885-b102e6231382.png">

<img width="267" alt="Capture d’écran 2019-05-29 à 16 14 36" src="https://user-images.githubusercontent.com/9989211/58564283-f4475c00-822c-11e9-869a-83a13d76a8df.png">

