### PR TITLE
Better instructions for baseHref when using context path

### DIFF
--- a/pages/production.md
+++ b/pages/production.md
@@ -64,6 +64,8 @@ Or when using Gradle, please type:
 
 `./gradlew -Pprod -Pwar bootWar`
 
+**Please note** that when building a JAR or WAR file with a context path, you will need to update webpack.prod.js with the proper baseHref.
+
 
 This will generate these files (if your application is called "jhipster"):
 
@@ -124,7 +126,7 @@ There are many other options that you can find in [Spring Boot documentation](ht
 
 ### Running the application under a Context Path
 
-When deploying a JHipster app to an Application Server or customizing your context-path, it is required to set the `baseHref` value in `webpack.common.js` equal to the expected context-path.
+When deploying a JHipster app to an Application Server or customizing your context-path, it is required to set the `baseHref` value in `webpack.common.js`or webpack.prod.js equal to the expected context-path.
 
 ## <a name="performance"></a> Performance optimizations
 


### PR DESCRIPTION
There are two minor changes to the documentation based on the normal usage of a production war file will usually use a context path and that normal development does not.