### PR TITLE
update cassandra integration test documentation

### DIFF
--- a/pages/running_tests.md
+++ b/pages/running_tests.md
@@ -41,7 +41,7 @@ Integration tests are done with the Spring Test Context framework, and are locat
 This Spring test context will use a specific test database to execute its tests:
 
 *   If you use an SQL database, JHipster will launch an in-memory H2 instance in order to use a temporary database for its integration tests. Liquibase will be run automatically, and will generate the database schema.
-*   If you use Cassandra, JHipster will launch an in-memory Cassandra instance using [CassandraUnit](https://github.com/jsevellec/cassandra-unit).
+*   If you use Cassandra, JHipster will launch a containerized version of Cassandra with Docker using [Testcontainers](https://www.testcontainers.org)
 *   If you use MongoDB, JHipster will launch an in-memory MongoDB instance using [de.flapdoodle.embed.mongo](https://github.com/flapdoodle-oss/de.flapdoodle.embed.mongo).
 *   If you use Elasticsearch, JHipster will launch an in-memory Elasticsearch instance using Spring Data Elasticsearch.
 *   If you use Couchbase, JHipster will launch a containerized version of Couchbase with Docker using [Couchbase TestContainers](https://github.com/differentway/testcontainers-java-module-couchbase).


### PR DESCRIPTION
clearly state docker is now required as we use testcontainers

closes https://github.com/jhipster/generator-jhipster/issues/10052