### PR TITLE
add explicit clean command to production build commands

### DIFF
--- a/pages/docker_compose.md
+++ b/pages/docker_compose.md
@@ -165,7 +165,7 @@ Follow these steps to do so:
 - Scale the MongoDB node service (you have to choose an odd number of nodes): `docker-compose -f src/main/docker/mongodb-cluster.yml scale <name_of_your_app>-mongodb-node=<X>`
 - Init the replica set (parameter X is the number of nodes you input in the previous step, folder is the folder where the YML file is located, it's `docker` by default): `docker container exec -it <yml_folder_name>_<name_of_your_app>-mongodb-node_1 mongo --eval 'var param=<X>, folder="<yml_folder_name>"' init_replicaset.js`
 - Init the shard: `docker container exec -it <yml_folder_name>_<name_of_your_app>-mongodb_1 mongo --eval 'sh.addShard("rs1/<yml_folder_name>_<name_of_your_app>-mongodb-node_1:27017")'`
-- Build a Docker image of your application: `./mvnw -Pprod verify jib:dockerBuild` or `./gradlew -Pprod bootJar jibDockerBuild`
+- Build a Docker image of your application: `./mvnw -Pprod clean verify jib:dockerBuild` or `./gradlew -Pprod clean bootJar jibDockerBuild`
 - Start your application: `docker-compose -f src/main/docker/app.yml up -d <name_of_your_app>-app`
 
 If you want to add or remove some MongoDB nodes, just repeat step 3 and 4.
@@ -178,7 +178,7 @@ Follow these steps to do so:
 - Build the image: `docker-compose -f src/main/docker/couchbase-cluster.yml build`
 - Run the database: `docker-compose -f src/main/docker/couchbase-cluster.yml up -d`
 - Scale the Couchbase node service (you have to choose an odd number of nodes): `docker-compose -f src/main/docker/couchbase-cluster.yml scale <name_of_your_app>-couchbase-node=<X>`
-- Build a Docker image of your application: `./mvnw -Pprod verify jib:dockerBuild` or `./gradlew -Pprod bootJar jibDockerBuild`
+- Build a Docker image of your application: `./mvnw -Pprod clean verify jib:dockerBuild` or `./gradlew -Pprod clean bootJar jibDockerBuild`
 - Start your application: `docker-compose -f src/main/docker/app.yml up -d <name_of_your_app>-app`
 
 ### Cassandra

--- a/pages/production.md
+++ b/pages/production.md
@@ -41,11 +41,11 @@ If you want more information on the available profiles, please go the section ti
 
 To package the application as a "production" JAR, with Maven please type:
 
-`./mvnw -Pprod verify`
+`./mvnw -Pprod clean verify`
 
 Or when using Gradle, please type:
 
-`./gradlew -Pprod bootJar`
+`./gradlew -Pprod clean bootJar`
 
 This will generate this file (if your application is called "jhipster"):
 
@@ -58,11 +58,11 @@ When using Gradle:
 
 To package the application as a "production" WAR, with Maven please type:
 
-`./mvnw -Pprod,war verify`
+`./mvnw -Pprod,war clean verify`
 
 Or when using Gradle, please type:
 
-`./gradlew -Pprod -Pwar bootWar`
+`./gradlew -Pprod -Pwar clean bootWar`
 
 **Please note** that when building a JAR or WAR file with a context path, you will need to update webpack.prod.js with the proper baseHref.
 


### PR DESCRIPTION
to be consistent with generated readme.

In general doing clean before production build seems reasonable to make sure
everything is build from a clean state imho.

closes https://github.com/jhipster/generator-jhipster/issues/10098