### PR TITLE
Fix to remove deprecation warning at startup

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,7 +5,7 @@ url: https://www.jhipster.tech
 github_repository_url: https://github.com/jhipster/jhipster.github.io
 kramdown:
   input: GFM
-gems:
+plugins:
   - jekyll-redirect-from
   - jemoji
 whitelist:


### PR DESCRIPTION
Fix for the deprecation warning at startup; ```The 'gems' configuration option has been renamed to 'plugins'. Please update your config file accordingly.```