### PR TITLE
Add Caffeine Cache as a JDL Option to the Readme

### DIFF
--- a/pages/jdl.md
+++ b/pages/jdl.md
@@ -891,8 +891,8 @@ Here are the application options supported in the JDL:
   <tr>
     <td>cacheProvider</td>
     <td>ehcache or hazelcast</td>
-    <td>ehcache, hazelcast, infinispan, no</td>
-    <td>ehcache for monoliths and gateways, hazelcast otherwise</td>
+    <td>ehcache, caffeine, hazelcast, infinispan, no</td>
+    <td>ehcache or caffeine for monoliths and gateways, hazelcast otherwise</td>
   </tr>
   <tr>
     <td>clientFramework</td>


### PR DESCRIPTION
The JDL options table does not mention Caffeine cache as an option; so I've added it. 

Related to; https://github.com/jhipster/jhipster.github.io/pull/794