### PR TITLE
Add Details about Oauth2 and Gmail Configuration 

### DIFF
--- a/tips/011_tip_configuring_email_in_jhipster.md
+++ b/tips/011_tip_configuring_email_in_jhipster.md
@@ -46,7 +46,10 @@ configuration document for more information on how to set this up.
 
 [https://support.google.com/accounts/answer/185833](https://support.google.com/accounts/answer/185833)
 
-This way you will be able to use two factor authentication as well as keep the "allow less secure apps" option off.   
+This way you will be able to use two factor authentication as well as keep the "allow less secure apps" option off. Alternatively you can also 
+use OAuth2 with Gmail and the configuration method is highlighted in the following document.
+
+[https://javaee.github.io/javamail/OAuth2](https://javaee.github.io/javamail/OAuth2)     
 
 ### 2. Email Config - Outlook.com
 

--- a/tips/011_tip_configuring_email_in_jhipster.md
+++ b/tips/011_tip_configuring_email_in_jhipster.md
@@ -46,7 +46,7 @@ configuration document for more information on how to set this up.
 
 [https://support.google.com/accounts/answer/185833](https://support.google.com/accounts/answer/185833)
 
-This way you will be able to use two factor authentication as well as keep the "allow less secure apps" option off. Alternatively you can also 
+This way you will be able to use two factor authentication as well as keep the "allow less secure apps" option off. You can also 
 use OAuth2 with Gmail and the configuration method is highlighted in the following document.
 
 [https://javaee.github.io/javamail/OAuth2](https://javaee.github.io/javamail/OAuth2)     


### PR DESCRIPTION
Since starting from JavaMail 1.5.5, OAuth2 is supported, I thought it is better to give information that it is possible to configure Gmail with OAuth2 as well. 