### PR TITLE
Bootstrap pager seems not exist anymore.

### DIFF
--- a/pages/creating_an_entity.md
+++ b/pages/creating_an_entity.md
@@ -161,8 +161,7 @@ Pagination uses [the Link header](http://tools.ietf.org/html/rfc5988), as in the
 When the entity is generated, JHipster provides 4 pagination options:
 
 *   No pagination (in that case, the back-end won't be paginated)
-*   A simple pager, based on [the Bootstrap pager](http://getbootstrap.com/components/#pagination-pager)
-*   A complete pagination system, based on [the Bootstrap pagination component](http://getbootstrap.com/components/#pagination)
+*   A complete pagination system, based on [the Bootstrap pagination component](https://getbootstrap.com/docs/4.3/components/pagination/){: target="_blank"}
 *   An infinite scroll system, based on [the infinite scroll directive](http://sroze.github.io/ngInfiniteScroll/)
 
 ## Updating an existing entity

--- a/pages/jdl/options.md
+++ b/pages/jdl/options.md
@@ -386,8 +386,8 @@ Here are the entity options supported in the JDL:
     <td>paginate</td>
     <td>binary</td>
     <td>no</td>
-    <td>pagination, infinite-scroll, pager, no</td>
-    <td>'pager' is only available in AngularJS, and pagination is forbidden when the application uses Cassandra</td>
+    <td>pagination, infinite-scroll, no</td>
+    <td>Pagination is forbidden when the application uses Cassandra</td>
   </tr>
   <tr>
     <td>search</td>


### PR DESCRIPTION
Updating pagination link. Link opens in another browser tab.
Table (in options.md) now reflects correctly excluded  'pager' option.