### PR TITLE
Make JDL more visible in docs

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -208,6 +208,7 @@
                                     </div>
                                 </div>
                             </li>
+                            <li {% if '/jdl/' == page.url %}class="active" {% endif %}><a href="{{ site.url }}/jdl/"><span class="icon fa fa-fw fa-star"></span><span class="title">JDL</span></a></li>
                             <li class="panel panel-default dropdown">
                                 <a data-toggle="collapse" href="#dropdown-5"><span class="icon fa fa-fw fa-sitemap"></span><span class="title">Microservices</span></a>
                                 <div id="dropdown-5" class="panel-collapse collapse">
@@ -316,7 +317,6 @@
                                 <div id="dropdown-11" class="panel-collapse collapse" style="height: 0px;">
                                     <div class="panel-body">
                                         <ul class="nav navbar-nav">
-                                            <li {% if '/jdl/' == page.url %}class="active" {% endif %}><a href="{{ site.url }}/jdl/"><i class="fa fa-fw fa-star"></i> JDL</a></li>
                                             <li><a href="https://start.jhipster.tech/jdl-studio/"><i class="fa fa-fw fa-terminal"></i> JDL Studio</a></li>
                                             <li {% if '/jhipster-ide/' == page.url %}class="active" {% endif %}>
                                                 <a href="{{ site.url }}/jhipster-ide/"><i class="fa fa-fw fa-object-group"></i> JHipster IDE</a></li>


### PR DESCRIPTION
SInce JDL is the integer part of JHipster and since we want to make it more integral we should make it more visible in docs instead of burying it under tools.

WDYT @jdubois @pascalgrimaud @MathieuAA ?