### PR TITLE
Update Packaging Format to JAR for JHipster Registry

### DIFF
--- a/pages/jhipster-registry.md
+++ b/pages/jhipster-registry.md
@@ -44,11 +44,11 @@ As a result:
 
 Once the JHipster Registry is running, you can check its configuration in the `Configuration > Cloud Config` menu. Please note that if you can't log in, it might be because the JWT signature key is not correctly set up, which is a sign that your configuration isn't good.
 
-### Using the pre-packaged WAR file
+### Using the pre-packaged JAR file
 
-The JHipster Registry is available as an executable WAR file on our [Releases page](https://github.com/jhipster/jhipster-registry/releases).
+The JHipster Registry is available as an executable JAR file on our [Releases page](https://github.com/jhipster/jhipster-registry/releases).
 
-Download the WAR file, and run it as a usual JHipster application, using the profile you want to use (see the previous section about profiles). For example, to run it using a Spring Cloud Config configuration stored in the `central-config` directory:
+Download the JAR file, and run it as a usual JHipster application, using the profile you want to use (see the previous section about profiles). For example, to run it using a Spring Cloud Config configuration stored in the `central-config` directory:
 
     ./jhipster-registry-<version>.jar --spring.security.user.password=admin --jhipster.security.authentication.jwt.secret=my-secret-key-which-should-be-changed-in-production-and-be-base64-encoded --spring.cloud.config.server.composite.0.type=native --spring.cloud.config.server.composite.0.search-locations=file:./central-config
 

--- a/pages/jhipster-registry.md
+++ b/pages/jhipster-registry.md
@@ -68,7 +68,7 @@ Similarly, to run the registry with the `prod` profile, adapt the arguments to y
 The JHipster Registry can be cloned/forked/downloaded directly from [jhipster/jhipster-registry](https://github.com/jhipster/jhipster-registry). As the JHipster Registry is also a JHipster-generated application, you can run it like any other JHipster application:
 
 - run it in development with `./mvnw` (for the Java server) and `yarn start` (for managing the front-end), it will use by default the `dev` profile and it will be available at [http://127.0.0.1:8761/](http://127.0.0.1:8761/).
-- use `./mvnw -Pprod package` to package it in production, and generate the usual JHipster executable WAR file. You can then run the WAR file using the `dev` or `prod` Spring profile, for example: `./jhipster-registry-<version>.jar --spring.profiles.active=prod`
+- use `./mvnw -Pprod package` to package it in production, and generate the usual JHipster executable JAR file. You can then run the JAR file using the `dev` or `prod` Spring profile, for example: `./jhipster-registry-<version>.jar --spring.profiles.active=prod`
 
 Please note that to use the `dev` and `composite` profile, you need to have a `central-config` directory with your configuration, so if you run `./jhipster-registry-<version>.jar --spring.profiles.active=dev`, you need to have that directory set up.
 


### PR DESCRIPTION
For some time (since v5.0.0 release) we have been using JARs as the artifact type. Thus it needs to be updated. 

@pascalgrimaud : Also I noticed that for [release v6.0.2](https://github.com/jhipster/jhipster-registry/releases/tag/v6.0.2) the JAR is missing. 😄 