### PR TITLE
Correcting Link Error Caused by Mixing Markdown and HTML

### DIFF
--- a/pages/installation.md
+++ b/pages/installation.md
@@ -224,5 +224,5 @@ On your machine, you should be able to:
         <li>use the docker-compose files</li>
         <li>build a Docker image with the docker daemon (Maven goal: <code>jib:dockerBuild</code> or Gradle task: <code>jibDockerBuild</code>)</li>
     </ul>
-    However, you will be able to use [jib](https://github.com/GoogleContainerTools/jib)'s daemonless mode which can build a docker image and push it to a registry without access to a docker daemon (Maven goal: <code>jib:build</code> or Gradle task: <code>jibBuild</code>). But you will need to setup credentials to the docker registry as a pre-requisite of building the app. See the [Jib plugin configuration documentations](https://github.com/GoogleContainerTools/jib/tree/master/jib-maven-plugin#configuration) for more details.
+    However, you will be able to use <a href="https://github.com/GoogleContainerTools/jib">jib</a>'s daemonless mode which can build a docker image and push it to a registry without access to a docker daemon (Maven goal: <code>jib:build</code> or Gradle task: <code>jibBuild</code>). But you will need to setup credentials to the docker registry as a pre-requisite of building the app. See the <a href="https://github.com/GoogleContainerTools/jib/tree/master/jib-maven-plugin#configuration">Jib plugin configuration documentations</a> for more details.
 </div>


### PR DESCRIPTION
This corrects a minor error caused by linking markdown and html; similar to https://github.com/jhipster/jhipster.github.io/pull/871

As you see currently the links doesn't parse on the relevant page (scroll to the last warning of the page); https://www.jhipster.tech/installation/#-installing-jhipster