### PR TITLE
Add Back Incorrectly Deleted HTML Element

### DIFF
--- a/index.html
+++ b/index.html
@@ -239,6 +239,7 @@ sitemap:
                                     </div>
                                 </div>
                             </div>
+                        </div>
                         <div class="col-sm-6 col-md-2">
                             <div class="thumbnail no-margin-bottom">
                                 <div class="logo-container">


### PR DESCRIPTION
I just saw that a `div` element was incorrectly deleted at commit https://github.com/jhipster/jhipster.github.io/commit/8d26be0664bad755b776e347b844ca9389057017. I've added it back in this PR. :smile: 

@jdubois : On another note, sorry I seem to have missed this repository in my [copyright update](https://github.com/jhipster/generator-jhipster/pull/11048); and thanks for correcting it. :smile: 
