### PR TITLE
remove redirect from /security to /using-uaa/

### DIFF
--- a/pages/using-uaa.md
+++ b/pages/using-uaa.md
@@ -2,8 +2,6 @@
 layout: default
 title: Using JHipster UAA for Microservice Security
 permalink: /using-uaa/
-redirect_from:
-  - /security.html
 sitemap:
     priority: 0.7
     lastmod: 2016-08-25T00:00:00-00:00


### PR DESCRIPTION
If you go to https://jhipster.tech/security it redirects to https://jhipster.tech/using-uaa/ instead of https://jhipster.tech/security/ due to the incorrect `redirect_from` config.

Because the `using-uaa` page is from after the conversion from `.html` -> folder paths, I don't think it is needed.