### PR TITLE
Add CLA agreement for JHipster Developers Association

### DIFF
--- a/JHipster-Developer-Association-CLA.md
+++ b/JHipster-Developer-Association-CLA.md
@@ -58,7 +58,7 @@ employer(s) has authorized you to make your Contributions on behalf of such empl
 (s) has waived all of their right, title or interest in or to your Contributions.
 
 
-**Disclaimer.** To the fullest extent permitted under applicable law, your Contributions are provided on an "asis"
+**Disclaimer.** To the fullest extent permitted under applicable law, your Contributions are provided on an "as is"
 basis, without any warranties or conditions, express or implied, including, without limitation, any implied
 warranties or conditions of non-infringement, merchantability or fitness for a particular purpose. You are not
 required to provide support for your Contributions, except to the extent you desire to provide support.

--- a/JHipster-Developer-Association-CLA.md
+++ b/JHipster-Developer-Association-CLA.md
@@ -1,0 +1,81 @@
+### JHipster Developers Association Individual Contributor License Agreement
+
+Thank you for your interest in contributing to open source software projects (**"Projects"**) 
+made available by [JHipster Developers Association](https://www.jhipster.tech/association/) 
+or its affiliates (the **"Association"**). This Individual Contributor License Agreement (**"CLA"**) sets out the 
+terms governing any source code, object code, bug fixes, configuration changes, tools, specifications, 
+documentation, data, materials, feedback, information or other works of authorship that you submit or 
+have submitted, in any form and in any manner, to the Association in respect of any of the Projects 
+(collectively **“Contributions”**). If you have any questions respecting this Agreement, 
+please contact **info@jhipster.tech**
+
+
+This license is for your protection as a Contributor as well as the protection of the Association 
+and its users; it does not change your rights to use your own Contributions for any other purpose.
+
+
+You agree that the following terms apply to all of your past, present and future Contributions. 
+Except for the licenses granted in this Agreement, you retain all of your right, title and interest in and 
+to your Contributions.
+
+**Copyright License.** You hereby grant, and agree to grant, to the Association a non-exclusive, perpetual, 
+irrevocable, worldwide, fully-paid, royalty-free, transferable copyright license to reproduce, prepare 
+derivative works of, publicly display, publicly perform, and distribute your Contributions and such 
+derivative works, with the right to sublicense the foregoing rights through multiple tiers of sublicensees.
+
+
+**Patent License.** You hereby grant, and agree to grant, to the Association a non-exclusive, perpetual, irrevocable,
+worldwide, fully-paid, royalty-free, transferable patent license to make, have made, use, offer to sell, sell,
+import, and otherwise transfer your Contributions, where such license applies only to those patent claims
+licensable by you that are necessarily infringed by your Contributions alone or by combination of your
+Contributions with the Project to which such Contributions were submitted, with the right to sublicense the
+foregoing rights through multiple tiers of sublicensees.
+
+
+**Moral Rights.** To the fullest extent permitted under applicable law, you hereby waive, and agree not to
+assert, all of your “moral rights” in or relating to your Contributions for the benefit of the Association, its assigns, and
+their respective direct and indirect sublicensees.
+
+
+**Third Party Content/Rights.** If your Contribution includes or is based on any source code, object code, bug
+fixes, configuration changes, tools, specifications, documentation, data, materials, feedback, information or
+other works of authorship that were not authored by you (“Third Party Content”) or if you are aware of any
+third party intellectual property or proprietary rights associated with your Contribution (“Third Party Rights”),
+then you agree to include with the submission of your Contribution full details respecting such Third Party
+Content and Third Party Rights, including, without limitation, identification of which aspects of your
+Contribution contain Third Party Content or are associated with Third Party Rights, the owner/author of the
+Third Party Content and Third Party Rights, where you obtained the Third Party Content, and any applicable
+third party license terms or restrictions respecting the Third Party Content and Third Party Rights. For greater
+certainty, the foregoing obligations respecting the identification of Third Party Content and Third Party Rights
+do not apply to any portion of a Project that is incorporated into your Contribution to that same Project.
+
+
+**Representations.** You represent that, other than the Third Party Content and Third Party Rights identified by
+you in accordance with this Agreement, you are the sole author of your Contributions and are legally entitled
+to grant the foregoing licenses and waivers in respect of your Contributions. If your Contributions were
+created in the course of your employment with your past or present employer(s), you represent that such
+employer(s) has authorized you to make your Contributions on behalf of such employer(s) or such employer
+(s) has waived all of their right, title or interest in or to your Contributions.
+
+
+**Disclaimer.** To the fullest extent permitted under applicable law, your Contributions are provided on an "asis"
+basis, without any warranties or conditions, express or implied, including, without limitation, any implied
+warranties or conditions of non-infringement, merchantability or fitness for a particular purpose. You are not
+required to provide support for your Contributions, except to the extent you desire to provide support.
+
+
+**No Obligation.** You acknowledge that the Association is under no obligation to use or incorporate your Contributions
+into any of the Projects. The decision to use or incorporate your Contributions into any of the Projects will be
+made at the sole discretion of the Association or its authorized delegates.
+
+
+**Disputes.** This Agreement shall be governed by and construed in accordance with the laws of France, 
+where the Association is registered, without giving effect to its principles or rules regarding conflicts of laws,
+other than such principles directing application of French law. The parties hereby submit to venue in, and
+jurisdiction of the courts located in France for purposes relating to this Agreement. In the event
+that any of the provisions of this Agreement shall be held by a court or other tribunal of competent jurisdiction
+to be unenforceable, the remaining portions hereof shall remain in full force and effect.
+
+
+**Assignment.** You agree that the Association may assign this Agreement, and all of its rights, obligations and licenses
+hereunder.

--- a/JHipster-Developer-Association-CLA.md
+++ b/JHipster-Developer-Association-CLA.md
@@ -7,7 +7,7 @@ terms governing any source code, object code, bug fixes, configuration changes, 
 documentation, data, materials, feedback, information or other works of authorship that you submit or 
 have submitted, in any form and in any manner, to the Association in respect of any of the Projects 
 (collectively **“Contributions”**). If you have any questions respecting this Agreement, 
-please contact **info@jhipster.tech**
+please contact **jhipster-developers-association@googlegroups.com**
 
 
 This license is for your protection as a Contributor as well as the protection of the Association 


### PR DESCRIPTION
@jdubois @pascalgrimaud @jhipster/developers please review and let me know if there is any concern with the CLA agreement propose.

I have based this on the [SAP CLA](https://gist.github.com/CLAassistant/bd1ea8ec8aa0357414e8) which was quite clear and simple and the terms are comparable and close to Apache CLA

Once we all agree I'll set up https://cla-assistant.io/ on the JHipster orgs to cover all projects under it