### PR TITLE
Add CircleCI to Documentation and Modify Existing CI Documentation

### DIFF
--- a/index.html
+++ b/index.html
@@ -910,6 +910,10 @@ sitemap:
                     <span class="title_sub_tech">GitLab CI</span>
                 </li>
                 <li class="clip img-circle new">
+                    <img src="images/logo/svg/circleci.svg"/>
+                    <span class="title_sub_tech">CircleCI</span>
+                </li>
+                <li class="clip img-circle new">
                     <img src="images/logo/azure-pipelines.png"/>
                     <span class="title_sub_tech">Azure Pipelines</span>
                 </li>

--- a/pages/setting_up_ci.md
+++ b/pages/setting_up_ci.md
@@ -27,6 +27,7 @@ JHipster should support the following CI systems out of the box:
 - GitLab CI: refer to the [GitLab CI Documentation](https://about.gitlab.com/gitlab-ci/)
 - Azure Pipelines: refer to the [Azure Pipelines Documentation](https://docs.microsoft.com/fr-fr/azure/devops/pipelines/?view=vsts)
 - GitHub Actions: refer to [GitHub Actions Documentation](https://github.com/features/actions)
+- CircleCI: refer to [CircleCI Documentation](https://circleci.com/docs/)
 
 ## Running the sub-generator
 
@@ -46,6 +47,7 @@ The CI/CD pipeline you want to generate:
 - GitLab CI
 - GitHub Actions
 - Travis CI
+- CircleCI
 
 **Note**: when you select Jenkins pipeline, a new `src/main/docker/jenkins.yml` file will be generated.
 So you can test Jenkins locally by running:
@@ -121,3 +123,6 @@ It will create all files needed by your Continuous Integration Tool.
 - Jenkins pipeline: you should use the [Credentials plugin](https://wiki.jenkins-ci.org/display/JENKINS/Credentials+Plugin)
 - GitLab CI: read the [documentation about secret-variables](https://docs.gitlab.com/ce/ci/variables/#secret-variables)
 - Travis CI: read the [environment variables](https://docs.travis-ci.com/user/environment-variables/)
+- GitHub Actions: read the [documentation about environment variables](https://help.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables)
+- Azure Pipelines: read the [documentation about predefined variables](https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml)
+- CircleCI: read the [documentation about environment variables](https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables)


### PR DESCRIPTION
Add information about CircleCI to existing continuous integration documents and modify documentation to include more information and documentation links.

Related to https://github.com/jhipster/generator-jhipster/issues/10671