### PR TITLE
Add Information About Heroku Account Verification

### DIFF
--- a/pages/heroku.md
+++ b/pages/heroku.md
@@ -39,6 +39,10 @@ To deploy your application to Heroku, run this command:
 
 This should package your application in "production" mode, create an Heroku application with a database, upload your code, and start the application.
 
+Depending on your database the sub-generator might install add-ons such as [JawsDB MySQL](https://elements.heroku.com/addons/jawsdb) 
+for MySQL databases. For these addons to be installed properly your [Heroku account needs to be verified](https://devcenter.heroku.com/articles/account-verification).
+Therefore to avoid any unexpected build failures, we would recommend verifying your Heroku account before starting this sub-generator.
+
 Note that if your application is a microservice, you will be prompted to provide a registry URL. Scroll down to learn how to do this.
 
 _Please be aware that your application must start under 90 seconds, or it will be shutdown. Depending on the platform load, starting under 90 seconds is not guaranteed!_


### PR DESCRIPTION
While working on https://github.com/jhipster/generator-jhipster/issues/11339, I noticed that if the Heroku account is not verified the build fails due to the inability to install add-ons (as highlighted in this [StackOverflow issue](https://stackoverflow.com/questions/44518035/jhipster-url-must-start-with-jdbc-error-on-heroku/44530428#44530428 )). I think we need to add this to the documentation as it's difficult to figure out from the build failure logs the reason. 

Related to https://github.com/jhipster/generator-jhipster/issues/11339