### PR TITLE
Add Sinhala and Bulgarian Language to Documentation

### DIFF
--- a/pages/installing_new_languages.md
+++ b/pages/installing_new_languages.md
@@ -28,6 +28,7 @@ These are the currently supported languages
 *   Armenian
 *   Belarusian
 *   Bengali
+*   Bulgarian
 *   Catalan
 *   Chinese (Simplified)
 *   Chinese (Traditional)

--- a/pages/installing_new_languages.md
+++ b/pages/installing_new_languages.md
@@ -56,7 +56,8 @@ These are the currently supported languages
 *   Romanian 
 *   Russian 
 *   Slovak 
-*   Serbian 
+*   Serbian
+*   Sinhala 
 *   Spanish 
 *   Swedish 
 *   Turkish 


### PR DESCRIPTION
This adds [Sinhala](https://en.wikipedia.org/wiki/Sinhala_language) and [Bulgarian](https://en.wikipedia.org/wiki/Bulgarian_language) languages to the documentation.

Related to https://github.com/jhipster/generator-jhipster/issues/11563