### PR TITLE
Fix docker command for the local SMTP Server

### DIFF
--- a/tips/015_tip_local_smtp_server.md
+++ b/tips/015_tip_local_smtp_server.md
@@ -17,5 +17,5 @@ The project [djfarrelly/maildev](https://github.com/djfarrelly/MailDev) is a sim
 To start locally the SMTP server with Docker:
 
 ```
-docker container run -d -p 1080:80 -p 25:25 djfarrelly/maildev
+docker run -d -p 1080:80 -p 25:25 djfarrelly/maildev
 ```


### PR DESCRIPTION
The command had an invalid argument which might throw people off if they're simply copying and pasting.