### PR TITLE
Minor Refactor to JDL Section Headings

### DIFF
--- a/pages/jdl/applications.md
+++ b/pages/jdl/applications.md
@@ -7,9 +7,9 @@ sitemap:
     lastmod: 2019-10-27T12:00:00-00:00
 ---
 
-# <i class="fa fa-star"></i> JHipster Domain Language (JDL)
+# <i class="fa fa-star"></i> JHipster Domain Language (JDL) - Applications
 
-## Applications
+## Summary
 
 1. [Syntax](#syntax)
 1. [Examples](#examples)

--- a/pages/jdl/deployments.md
+++ b/pages/jdl/deployments.md
@@ -7,9 +7,9 @@ sitemap:
     lastmod: 2019-10-27T12:00:00-00:00
 ---
 
-# <i class="fa fa-star"></i> JHipster Domain Language (JDL)
+# <i class="fa fa-star"></i> JHipster Domain Language (JDL) - Deployments
 
-## Deployments
+## Summary
 
 1. [Syntax](#syntax)
 1. [Examples](#examples)

--- a/pages/jdl/entities.md
+++ b/pages/jdl/entities.md
@@ -7,9 +7,9 @@ sitemap:
     lastmod: 2019-10-27T12:00:00-00:00
 ---
 
-# <i class="fa fa-star"></i> JHipster Domain Language (JDL)
+# <i class="fa fa-star"></i> JHipster Domain Language (JDL) - Entities
 
-## Entities
+## Summary
 
 1. [Syntax](#syntax)
 1. [Examples](#examples)

--- a/pages/jdl/enums.md
+++ b/pages/jdl/enums.md
@@ -7,9 +7,9 @@ sitemap:
     lastmod: 2019-10-27T12:00:00-00:00
 ---
 
-# <i class="fa fa-star"></i> JHipster Domain Language (JDL)
+# <i class="fa fa-star"></i> JHipster Domain Language (JDL) - Enums
 
-## Enums
+## Summary
 
 1. [Syntax](#syntax)
 1. [Examples](#examples)

--- a/pages/jdl/getting-started.md
+++ b/pages/jdl/getting-started.md
@@ -7,10 +7,10 @@ sitemap:
     lastmod: 2019-10-27T12:00:00-00:00
 ---
 
-# <i class="fa fa-star"></i> JHipster Domain Language (JDL)
+# <i class="fa fa-star"></i> JHipster Domain Language (JDL) - Getting Started
 
 
-## Getting Started
+## Summary
 
 In this page, you'll learn about the JDL and how to create applications and everything around them.
 

--- a/pages/jdl/intro.md
+++ b/pages/jdl/intro.md
@@ -16,7 +16,6 @@ You can use our online [JDL-Studio](https://start.jhipster.tech/jdl-studio/) or 
 [JHipster IDE](https://www.jhipster.tech/jhipster-ide/) plugins/extensions, which are available for:
   - [Eclipse](https://marketplace.eclipse.org/content/jhipster-ide), 
   - [VS Code](https://marketplace.visualstudio.com/items?itemName=jhipster-ide.jdl)
-  - [Atom](https://atom.io/packages/ide-jhipster)
 
 to create a JDL file and its UML visualization. You can create and export or share the URL of your JDL model as well.
 

--- a/pages/jdl/options.md
+++ b/pages/jdl/options.md
@@ -7,9 +7,9 @@ sitemap:
     lastmod: 2019-11-02T12:00:00-00:00
 ---
 
-# <i class="fa fa-star"></i> JHipster Domain Language (JDL)
+# <i class="fa fa-star"></i> JHipster Domain Language (JDL) - Options
 
-## Options
+## Summary
 
 In JHipster, you can specify options for your entities such as pagination or DTO.
 You can do the same with the JDL, either with annotations on the entity, or with the following syntax:

--- a/pages/jdl/relationships.md
+++ b/pages/jdl/relationships.md
@@ -7,9 +7,9 @@ sitemap:
     lastmod: 2019-11-03T12:00:00-00:00
 ---
 
-# <i class="fa fa-star"></i> JHipster Domain Language (JDL)
+# <i class="fa fa-star"></i> JHipster Domain Language (JDL) - Relationships
 
-## Relationships
+## Summary
 
 1. [Relationship types](#relationship-types)
 1. [Relationship methods](#relationship-methods)


### PR DESCRIPTION
This refactors the jdl section headings so that they appear in the search better. Also this removes the [Atom JHipster plugin](https://atom.io/packages/ide-jhipster) as it's deprecated.

Fixes https://github.com/jhipster/generator-jhipster/issues/11596