### PR TITLE
skipUserManagement should be documented `false`

### DIFF
--- a/pages/jdl/applications.md
+++ b/pages/jdl/applications.md
@@ -412,7 +412,7 @@ Here are the application options supported in the JDL:
   </tr>
   <tr>
     <td>skipUserManagement</td>
-    <td>true</td>
+    <td>false</td>
     <td></td>
     <td></td>
   </tr>


### PR DESCRIPTION
According to this document:
https://www.jhipster.tech/creating-an-app/
> --skip-user-management - Skip the user management generation, both on the back-end and on the front-end (Default: false)

the skipUserManagement config should be documented as `false` instead `true`