### PR TITLE
Change link to point to JDL page

### DIFF
--- a/pages/jhipster_uml.md
+++ b/pages/jhipster_uml.md
@@ -15,7 +15,7 @@ Please note that this project is deprecated and shouldn't be used anymore.
 
 Instead, we suggest you use the JDL export feature of this project to export your XMI files to a JDL file that you can use and make models of your entities with JDL Studio.
 
-To learn more about the JDL, head [here]({{ site.url }}/profiles/).
+To learn more about the JDL, head [here]({{ site.url }}/jdl/).
 
 ***
 


### PR DESCRIPTION
This page (https://www.jhipster.tech/jhipster-uml/) was linking to https://www.jhipster.tech/profile/ instead of https://www.jhipster.tech/jdl/. Now fixed.