### PR TITLE
Fix .net sample app url

### DIFF
--- a/index.html
+++ b/index.html
@@ -516,7 +516,7 @@ sitemap:
                             </ul>
                         </li>
                         <li><a href="https://github.com/jhipster/jhipster-sample-app-nodejs" target="_blank" rel="noopener">Node.js + Angular</a></li>
-                        <li><a href="https://github.com/jhipster/jhipster-net-sample-app-template" target="_blank" rel="noopener">.NET + Angular</a></li>
+                        <li><a href="https://github.com/jhipster/jhipster-sample-app-dotnetcore" target="_blank" rel="noopener">.NET + Angular</a></li>
                     </ul>
                     <p>
                         JHipster is Open Source, and all development is done


### PR DESCRIPTION
The repo https://github.com/jhipster/jhipster-net-sample-app-template is obsolete. 
The repo who was generated by the generator is https://github.com/jhipster/jhipster-sample-app-dotnetcore