### PR TITLE
Add Tip About Time Drift in Docker

### DIFF
--- a/pages/tips.md
+++ b/pages/tips.md
@@ -36,3 +36,4 @@ _If you want to contribute, don't hesitate to send us a Pull Request with your t
 1. [Improve developer experience if opening only front end in the IDE]({{ site.url }}/tips/029_tip_frontend_only.html)
 1. [Configure Redis leader follower(master-slave) replication]({{ site.url }}/tips/030_tip_redis_replication.html)
 1. [Running Protractor e2e tests within Intellij IDEA]({{ site.url }}/tips/031_tip_e2e_intellij.html)
+1. [Time Drift in Docker]({{ site.url }}/tips/032_tip_time_drift_docker.html)

--- a/tips/032_tip_time_drift_docker.md
+++ b/tips/032_tip_time_drift_docker.md
@@ -1,0 +1,19 @@
+---
+layout: default
+title: Time Drift in Docker
+sitemap:
+priority: 0.1
+lastmod: 2020-05-02T06:14:00-00:00
+---
+
+# Time Drift in Docker
+
+**Tip submitted by [@SudharakaP](https://github.com/SudharakaP)**
+
+One of the things that should be taken into account when running Docker for extended periods of time (with sleep cycles in between), is that there are instances were a 
+time drift between the Docker container(s) and OS clock can occur.
+
+This results in hard to find bugs such as [https://github.com/jhipster/generator-jhipster/issues/11659](https://github.com/jhipster/generator-jhipster/issues/11659). 
+
+Docker time drift has been reported for both [Macs](https://github.com/docker/for-mac/issues/2076) and [Windows](https://github.com/docker/for-win/issues/4526) 
+and the simplest solution is to restart the Docker container(s) after extended periods of sleep cycles. 


### PR DESCRIPTION
This adds a tip about the time drift that can occur in docker containers when sleeping for extended periods of time.

Closes https://github.com/jhipster/generator-jhipster/issues/11659