### PR TITLE
JDL: reorder entity types to group dates and blobs

### DIFF
--- a/pages/jdl/entities.md
+++ b/pages/jdl/entities.md
@@ -251,13 +251,13 @@ Common databases:
     <td><dfn>required, unique</dfn></td>
   </tr>
   <tr>
-      <td></td>
-      <td>ByteBuffer</td>
-      <td><dfn>required, minbytes, maxbytes, unique</dfn></td>
-    </tr>
+    <td>ZonedDateTime</td>
+    <td>ZonedDateTime</td>
+    <td><dfn>required, unique</dfn></td>
+  </tr>
   <tr>
-    <td>ZonedDateTime</td>
-    <td>ZonedDateTime</td>
+    <td>Instant</td>
+    <td>Instant</td>
     <td><dfn>required, unique</dfn></td>
   </tr>
   <tr>
@@ -291,8 +291,8 @@ Common databases:
     <td><dfn>required, unique</dfn></td>
   </tr>
   <tr>
-    <td>Instant</td>
-    <td>Instant</td>
-    <td><dfn>required, unique</dfn></td>
+    <td></td>
+    <td>ByteBuffer</td>
+    <td><dfn>required, minbytes, maxbytes, unique</dfn></td>
   </tr>
 </table>


### PR DESCRIPTION
Instant was at the end of the table, it's more logic to have it besides LocalDate, ZonedDateTime and Duration.
Ditto for ByteBuffer: it should be next to blob types