### PR TITLE
add comunity tutorials section

### DIFF
--- a/index.html
+++ b/index.html
@@ -470,7 +470,7 @@ sitemap:
                         </ul>
                         <h3>News</h3>
                         <ul>
-			                <li><b>Full Stack Development with JHipster - Second edition</b> by Deepu K Sasidharan and Sendil Kumar is published. Get it on <a href="https://www.packtpub.com/web-development/full-stack-development-with-jhipster-second-edition" target="_blank" rel="noopener">Packt</a> and <a href="https://smile.amazon.com/Full-Stack-Development-JHipster-microservices/dp/1838824987" target="_blank" rel="noopener">Amazon</a>.</li>
+			    <li><b>Full Stack Development with JHipster - Second edition</b> by Deepu K Sasidharan and Sendil Kumar is published. Get it on <a href="https://www.packtpub.com/web-development/full-stack-development-with-jhipster-second-edition" target="_blank" rel="noopener">Packt</a> and <a href="https://smile.amazon.com/Full-Stack-Development-JHipster-microservices/dp/1838824987" target="_blank" rel="noopener">Amazon</a>.</li>
                             <li><b>The JHipster Mini-Book 5.0</b> by Matt Raible is now available! Download it for free from <a href="https://www.infoq.com/minibooks/jhipster-mini-book-5" target="_blank" rel="noopener">InfoQ</a> or buy the print version <a href="http://www.lulu.com/shop/matt-raible/the-jhipster-mini-book/paperback/product-23871310.html">from Lulu</a>.</li>
                         </ul>
                     </div>
@@ -581,24 +581,18 @@ sitemap:
             <div class="row">
                 <div class="col-md-12">
                     <div>
-                        <h3>Online trainings (MOOCs)</h3>
+                        <h3>Books</h3>
+                        <ul>
+                            <li><a href="https://www.infoq.com/minibooks/jhipster-mini-book-5" target="_blank" rel="noopener">The JHipster Mini-Book 5.0</a> by Matt Raible. This edition includes new sections on progressive web apps (PWA), code quality, and securing user data.</li>
+			    <li><b>Full Stack Development with JHipster - Second edition</b> by Deepu K Sasidharan and Sendil Kumar. Get it on <a href="https://www.packtpub.com/web-development/full-stack-development-with-jhipster-second-edition" target="_blank" rel="noopener">Packt</a> and <a href="https://smile.amazon.com/Full-Stack-Development-JHipster-microservices/dp/1838824987" target="_blank" rel="noopener">Amazon</a>.</li>
+                        </ul>
+			<h3>Community Tutorials/Trainings</h3>
                         <ul>
                             <li><a href="https://www.pluralsight.com/courses/play-by-play-developing-microservices-mobile-apps-jhipster" target="_blank" rel="noopener">Play by Play: Developing Microservices and Mobile Apps with JHipster</a> by <a href="https://twitter.com/mraible" target="_blank" rel="noopener">Matt Raible</a> and <a href="https://twitter.com/mhi_inc">Michael Hoffman</a></li>
                             <li><a href="https://therealdanvega.teachable.com/p/jhipster/?product_id=456739&coupon_code=JHIPSTER" target="_blank" rel="noopener">Angular 4 Java Developers by Dan Vega and John Thompson</a> (by using this link, you will get a big discount over the normal price!)</li>
                             <li>JHipster: Build and Deploy Spring Boot Microservices by Chris Anatalio (<a href="https://linkedin-learning.pxf.io/c/1252615/449670/8005?u=https%3A%2F%2Fwww.linkedin.com%2Flearning%2Fjhipster-build-and-deploy-spring-boot-microservices%3Ftrk%3Dinsiders_43129714_learning" target="_blank" rel="noopener">LinkedIn Learning</a>, <a href="https://www.lynda.com/course-tutorials/JHipster-Build-Deploy-Microservices/624352-2.html" target="_blank" rel="noopener">Lynda.com</a>)</li>
 			    <li>JHipster free course: <a href="https://trainings.com/course/Rapid-Development-with-JHipster-Spring-and-Angular-6/view" target="_blank" rel="noopener">Rapid application development using JHipster-Angular-Springboot by Subbaraja Malepati</a> ,(<a href="https://trainings.com" target="_blank" rel="noopener">Trainings.com</a>)</li>
-                        </ul>
-                        <h3>New books</h3>
-                        <ul>
-                            <li><a href="https://www.infoq.com/minibooks/jhipster-mini-book-5" target="_blank" rel="noopener">The JHipster Mini-Book 5.0</a> by Matt Raible. This edition includes new sections on progressive web apps (PWA), code quality, and securing user data.</li>
-			    <li><b>Full Stack Development with JHipster - Second edition</b> by Deepu K Sasidharan and Sendil Kumar. Get it on <a href="https://www.packtpub.com/web-development/full-stack-development-with-jhipster-second-edition" target="_blank" rel="noopener">Packt</a> and <a href="https://smile.amazon.com/Full-Stack-Development-JHipster-microservices/dp/1838824987" target="_blank" rel="noopener">Amazon</a>.</li>
-                        </ul>
-                        <h3>Free Collaborative learning</h3>
-			            <ul>
                             <li>Learn by doing with <a href="https://www.spingular.com" target="_blank" rel="noopener">Spingular</a>. Join a live collaborative project made with Jhipster!: Spingular Chat w/Websockets</li>
-                        </ul>
-                        <h3>Community Tutorials/Blogs</h3>
-                        <ul>
                             <li><a href="https://betterprojectsfaster.com/learn/tutorial-jhipster-docker-01" target="_blank" rel="noopener">Better Java Projects Faster with JHipster and Docker</a> (3 part series) by <a href="https://betterprojectsfaster.com/about/" target="_blank" rel="noopener">Karsten Silz</a></li>
                         </ul>
                     </div>

--- a/index.html
+++ b/index.html
@@ -597,6 +597,10 @@ sitemap:
 			            <ul>
                             <li>Learn by doing with <a href="https://www.spingular.com" target="_blank" rel="noopener">Spingular</a>. Join a live collaborative project made with Jhipster!: Spingular Chat w/Websockets</li>
                         </ul>
+                        <h3>Community Tutorials/Blogs</h3>
+                        <ul>
+                            <li><a href="https://betterprojectsfaster.com/learn/tutorial-jhipster-docker-01" target="_blank" rel="noopener">Better Java Projects Faster with JHipster and Docker</a> (3 part series) by <a href="https://betterprojectsfaster.com/about/" target="_blank" rel="noopener">Karsten Silz</a></li>
+                        </ul>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
This is related to https://github.com/jhipster/generator-jhipster/issues/11783

I think the tutorial is well written and shows how jhipster is used in reality with both pros and cons. So I have put a new section under "Learn" for community tutorials. What do you think, should we do that?