### PR TITLE
remove non existing downloads property from marketplace items

### DIFF
--- a/index.html
+++ b/index.html
@@ -1007,7 +1007,7 @@ sitemap:
                 <br>
             </div>
             <div class="row">
-                <div ng-cloak ng-repeat="module in modules | filter: searchText | orderBy: '-downloads' | limitTo:16">
+                <div ng-cloak ng-repeat="module in modules | filter: searchText | orderBy: '-score.detail.popularity' | limitTo:16">
                     <div class="clearfix" ng-if="$index % 4 == 0"></div>
                     <div class="col-lg-3 col-md-6 col-sm-6 col-xs-12">
                         <a ng-href="{{ site.url }}/modules/marketplace/#/details/{(module.package.name)}"

--- a/modules/marketplace/list/list.html
+++ b/modules/marketplace/list/list.html
@@ -5,7 +5,7 @@
         <input class="form-control search-field" ng-model="searchText" placeholder="Filter by name or keyword" id="search-field">
         <label class="fa fa-search inline-search" for="search-field"></label>
     </div>
-    <div class="row" ng-repeat="module in modules | filter:searchText | orderBy:'-downloads'">
+    <div class="row" ng-repeat="module in modules | filter:searchText | orderBy:'-score.detail.popularity'">
         <div class="col-xs-12">
             <div class="card profile">
                 <div class="card-header">
@@ -25,7 +25,6 @@
                 <div class="card-footer">
                     <a type="button" class="btn btn-info" ng-click="details(module)">Details</a>
                     <a type="button" class="btn btn-default" ng-href="{(module.package.links.homepage)}">Home page</a>
-                    {(module.downloads)} downloads last month.
                     <div class="pull-right hidden-xs hidden-sm">
                         <span  ng-repeat="keyword in module.package.keywords">
                             <span class="label label-success keyword" ng-if="keyword === 'jhipster-blueprint'">{( keyword )}</span>


### PR DESCRIPTION
It seems the `downloads` property does not exist in the npm api anymore.
This pr removes the broken display and uses order by popularity (instead of the final score, which leads to little changes in the order).

![image](https://user-images.githubusercontent.com/203401/82603521-18751900-9bb3-11ea-9abf-5db51864bd9c.png)
