### PR TITLE
switch to registry.npmjs.org instead of api

### DIFF
--- a/js/marketplace-list.js
+++ b/js/marketplace-list.js
@@ -29,7 +29,7 @@
                         $scope.moduleConfig = moduleConfig;
 
                         $scope.modules = []
-                        angular.forEach(res.results, function(module, key) {
+                        angular.forEach(res.objects, function(module, key) {
                             if(!($scope.moduleConfig.blacklistedModules && $scope.moduleConfig.blacklistedModules[module.package.name])){
                                 $scope.modules.push(module);
                                 modulesList.push(module.package.name);

--- a/js/services.js
+++ b/js/services.js
@@ -66,7 +66,7 @@
             },
             getAllModules: function (start, size) {
                 /* Get all Jhipster modules */
-                return $http.get('https://api.npms.io/v2/search?q=keywords%3Ajhipster-module%2Cjhipster-blueprint&from=' + start + '&size=' + size).success(function (resp) {
+                return $http.get('http://registry.npmjs.org/-/v1/search?text=keywords:jhipster-blueprint,jhipster-module&from=' + start + '&size=' + size).success(function (resp) {
                     return resp;
                 });
             },

--- a/js/services.js
+++ b/js/services.js
@@ -66,7 +66,7 @@
             },
             getAllModules: function (start, size) {
                 /* Get all Jhipster modules */
-                return $http.get('http://registry.npmjs.org/-/v1/search?text=keywords:jhipster-blueprint,jhipster-module&from=' + start + '&size=' + size).success(function (resp) {
+                return $http.get('https://registry.npmjs.org/-/v1/search?text=keywords:jhipster-blueprint,jhipster-module&from=' + start + '&size=' + size).success(function (resp) {
                     return resp;
                 });
             },

--- a/modules/marketplace/list/list.html
+++ b/modules/marketplace/list/list.html
@@ -5,7 +5,7 @@
         <input class="form-control search-field" ng-model="searchText" placeholder="Filter by name or keyword" id="search-field">
         <label class="fa fa-search inline-search" for="search-field"></label>
     </div>
-    <div class="row" ng-repeat="module in modules | filter:searchText | orderBy:'-score.detail.popularity'">
+    <div class="row" ng-repeat="module in modules | filter:searchText | orderBy:'-searchScore'">
         <div class="col-xs-12">
             <div class="card profile">
                 <div class="card-header">


### PR DESCRIPTION
As suggested on the mailinglist we use registry.npmjs.org instead of api.npmjs.io. This has a bit changed order, but returns e.g. micronaut blueprint and seems to return more recent versions (e.g. vuejs 1.8.0 while 1.8.1 is the latest release).