### PR TITLE
Fix typos

### DIFF
--- a/modules/creating_a_blueprint.md
+++ b/modules/creating_a_blueprint.md
@@ -32,7 +32,7 @@ The [JHipster Kotlin](https://github.com/jhipster/jhipster-kotlin) blueprint rep
 
 It is our official blueprint that showcases how you can create your own blueprint.
 
-The [JHipster Sample Blueprint](https://github.com/hipster-labs/generator-jhipster-sample-blueprint) shows how a client sub-generator can be overriden.
+The [JHipster Sample Blueprint](https://github.com/hipster-labs/generator-jhipster-sample-blueprint) shows how a client sub-generator can be overridden.
 
 Or, you can use the [JHipster blueprint generator](https://github.com/jhipster/generator-jhipster-blueprint) to help you to initialize your blueprint. 
 

--- a/pages/azure.md
+++ b/pages/azure.md
@@ -29,7 +29,7 @@ sitemap:
 ## <a name="1"></a> Installing the "az CLI"
 
 You can manage your Azure resources using the [Web-based Azure portal](https://portal.azure.com/?WT.mc_id=online-jhipster-judubois) or using [the Azure
-command-line inteface](https://docs.microsoft.com/cli/azure/get-started-with-azure-cli/?WT.mc_id=online-jhipster-judubois), also known as the "az CLI".
+command-line interface](https://docs.microsoft.com/cli/azure/get-started-with-azure-cli/?WT.mc_id=online-jhipster-judubois), also known as the "az CLI".
 
 As with JHipster we always automate everything, installing this "az CLI" is mandatory in order to work with any of the below options.
 

--- a/pages/configuring-ide-visual-studio-code.md
+++ b/pages/configuring-ide-visual-studio-code.md
@@ -25,7 +25,7 @@ You can install it by using the Visual Studio Code marketplace:
 
 ## Java Code Support
 
-Visual Studio Code has a Java extension developped by Red Hat. It has a good Java support, using Maven or Gradle.
+Visual Studio Code has a Java extension developed by Red Hat. It has a good Java support, using Maven or Gradle.
 
 You can install it by using the Visual Studio Code marketplace:
 

--- a/pages/creating_an_app.md
+++ b/pages/creating_an_app.md
@@ -206,7 +206,7 @@ jhipster --blueprint kotlin
 
 The name of the blueprint is saved in the `.yo-rc.json` and will be automatically used while executing sub-generators like `entity`, `spring-controller` and `spring-service`.
 
-If a blueprint doesn't implement a specific sub-generator, it will be skiped and the JHipster templates for the same sub-generator will be used.
+If a blueprint doesn't implement a specific sub-generator, it will be skipped and the JHipster templates for the same sub-generator will be used.
 
 **Note:** An application can use only one blueprint, multiple blueprints are not supported yet.
 

--- a/pages/dependency-vulnerabities-check.md
+++ b/pages/dependency-vulnerabities-check.md
@@ -17,7 +17,7 @@ According to [OWASP Top 10 Most Critical Web Application Security Risks](https:/
 
 ## Why the dependency check is not provided by default by JHipster
 
-Proposing a dependency check by default in JHipster build has been discussed a couple of times ([#6329](https://github.com/jhipster/generator-jhipster/issues/6329), [#8191](https://github.com/jhipster/generator-jhipster/issues/8191)). To summarise, it is complicated to have a realistic report (removing false-positive) and context dependant (security is always a trade off between the actual risk/criticity and the effort to prevent it).
+Proposing a dependency check by default in JHipster build has been discussed a couple of times ([#6329](https://github.com/jhipster/generator-jhipster/issues/6329), [#8191](https://github.com/jhipster/generator-jhipster/issues/8191)). To summarise, it is complicated to have a realistic report (removing false-positive) and context dependent (security is always a trade off between the actual risk/criticity and the effort to prevent it).
 
 However we highly recommend using a dependency analysis tool such as [Dependabot](https://dependabot.com/) or [Snyk](https://snyk.io/) if you are using JHipster in production.  
 

--- a/pages/development.md
+++ b/pages/development.md
@@ -188,11 +188,11 @@ If you use the [entity sub-generator]({{ site.url }}/creating-an-entity/), here 
 
 ### Database updates with the Maven liquibase:diff goal
 
-If you have choosen to use MySQL, MariaDB or PostgreSQL in development, you can use the `./mvnw liquibase:diff` goal to automatically generate a changelog.
+If you have chosen to use MySQL, MariaDB or PostgreSQL in development, you can use the `./mvnw liquibase:diff` goal to automatically generate a changelog.
 
 If you are running H2 with disk-based persistence, this workflow is not yet working perfectly, but you can start trying to use it (and send us feedback!).
 
-[Liquibase Hibernate](https://github.com/liquibase/liquibase-hibernate) is a Maven plugin that is configured in your pom.xml, and is independant from your Spring application.yml file, so if you have changed the default settings (for example, changed the database password), you need to modify both files.
+[Liquibase Hibernate](https://github.com/liquibase/liquibase-hibernate) is a Maven plugin that is configured in your pom.xml, and is independent from your Spring application.yml file, so if you have changed the default settings (for example, changed the database password), you need to modify both files.
 
 Here is the development workflow:
 

--- a/pages/entities-filtering.md
+++ b/pages/entities-filtering.md
@@ -65,7 +65,7 @@ To prove that the generated criteria is working, and Spring is well configured, 
 
 ### Angular
 
-When using Angular, the propper way to take advantage of this useful feature would look like this:
+When using Angular, the proper way to take advantage of this useful feature would look like this:
 
 * Equals (same applies for `contains` and `notEquals`)
 ```javascript

--- a/pages/jhipster_uml.md
+++ b/pages/jhipster_uml.md
@@ -594,7 +594,7 @@ However, a few guidelines must be respected:
 
 - The editor's class name must be capitalized (Modelio -> `ModelioParser`, UML Designer -> `UMLDesignerParser`).
 
-Concerning the EditorDetector, it can detect the editor that created your XMI file. For that to happen, you must first locate where the editor is mentionned in the XMI file, and then add the code that returns your editor just like [here](https://github.com/jhipster/jhipster-uml/blob/master/lib/editors/editor_detector.js#L23). If your editor can't be detected, add it [here](https://github.com/jhipster/jhipster-uml/blob/master/lib/editors/editors.js#L23), and indicate its name just like it has been done for UML Designer [here](https://github.com/jhipster/jhipster-uml/blob/master/lib/editors/editor_detector.js#L56).
+Concerning the EditorDetector, it can detect the editor that created your XMI file. For that to happen, you must first locate where the editor is mentioned in the XMI file, and then add the code that returns your editor just like [here](https://github.com/jhipster/jhipster-uml/blob/master/lib/editors/editor_detector.js#L23). If your editor can't be detected, add it [here](https://github.com/jhipster/jhipster-uml/blob/master/lib/editors/editors.js#L23), and indicate its name just like it has been done for UML Designer [here](https://github.com/jhipster/jhipster-uml/blob/master/lib/editors/editor_detector.js#L56).
 
 
 #### Testing

--- a/pages/separating-front-end-and-api.md
+++ b/pages/separating-front-end-and-api.md
@@ -47,7 +47,7 @@ Once the front-end and back-end have been separated, the issue will be how to ha
 - All API calls will use a `/api` prefix. If you are using Angular, there is also a specific `SERVER_API_URL` constant, defined in the `webpack.common.js` configuration, that can enrich this prefix. For example, you can use `"http://api.jhipster.tech:8081/"` as a back-end API server (If you do this, please read our documentation on CORS below).
 - Calls to `/` serve static assets (from the front-end), which should not be cached by the browser.
 - Calls to `/app` (which contains the client-side application) and to `/content` (which contains the static content, like images and CSS) should be cached in production, as those assets are hashed.
-- Calls to a non-existant route should forward the request to `index.html`. This is normally handled in the backend through `ClientForwardController`. When deploying the client separately, this needs to be configured.  See the [Angular](https://angular.io/guide/deployment#server-configuration) or [React](https://facebook.github.io/create-react-app/docs/deployment) documentation for several examples.
+- Calls to a non-existent route should forward the request to `index.html`. This is normally handled in the backend through `ClientForwardController`. When deploying the client separately, this needs to be configured.  See the [Angular](https://angular.io/guide/deployment#server-configuration) or [React](https://facebook.github.io/create-react-app/docs/deployment) documentation for several examples.
 
 # Using BrowserSync
 

--- a/presentation/index.html
+++ b/presentation/index.html
@@ -154,7 +154,7 @@
                         <h3>Jest runs unit tests on your JavaScript code</h3>
                         <ul>
                             <li>It works with <i>jsdom</i>, a virtual DOM technology</li>
-                            <li>It is <i>very</i> fast, and can run continously in the background</li>
+                            <li>It is <i>very</i> fast, and can run continuously in the background</li>
                         </ul>
                         <pre>
                             <code data-trim contenteditable>npm test</code>
@@ -431,7 +431,7 @@ public void saveAccount(@RequestBody UserDTO userDTO) {
                         <h3>JHipster makes everything just work together</h3>
                         <ul>
                             <li>JHipster creates a complete working application, with all those technologies</li>
-                            <li>Everthing just works out-of-the-box</li>
+                            <li>Everything just works out-of-the-box</li>
                             <li>You have your Webpack tasks working great with your Maven goals!</li>
                             <li>You have Docker configuration to run everything smoothly!</li>
                         </ul>


### PR DESCRIPTION
Hey,

This huge PR will fix : 

- 1 typo in `modules/creating_a_blueprint.md`
- 1 typo in `pages/azure.md`
- 1 typo in `pages/configuring-ide-visual-studio-code.md`
- 1 typo in `pages/creating_an_app.md`
- 1 typo in `pages/dependency-vulnerabities-check.md`
- 2 typos in `pages/development.md`
- 1 typo in `pages/entities-filtering.md`
- 1 typo in `pages/jhipster_uml.md`
- 1 typo in `pages/separating-front-end-and-api.md`
- 2 typos in `presentation/index.html`



Ciao! :robot: