### PR TITLE
update heroku documentation

### DIFF
--- a/pages/common-application-properties.md
+++ b/pages/common-application-properties.md
@@ -98,10 +98,18 @@ Here is a documentation for those properties:
                 servers: localhost:11211 # Comma or whitespace separated list of servers' addresses
                 expiration: 300 # Expiration time (in seconds) for the cache
                 use-binary-protocol: true # Binary protocol is recommended for performance (and security)
+                authentication: # if authentication is required you can set it with these parameters. Disabled by default
+                    enabled: false,
+                    # username: unset by default
+                    # password: unset by default
             redis: # Redis configuration
                 expiration: 3600 # By default objects stay 1 hour (in seconds) in the cache
                 server: redis://localhost:6379 # Server address
                 cluster: false
+                connectionPoolSize: 64,
+                connectionMinimumIdleSize: 24,
+                subscriptionConnectionPoolSize: 50,
+                subscriptionConnectionMinimumIdleSize: 1
 
         # E-mail properties
         mail:

--- a/pages/heroku.md
+++ b/pages/heroku.md
@@ -6,14 +6,14 @@ redirect_from:
   - /heroku.html
 sitemap:
     priority: 0.7
-    lastmod: 2014-09-08T00:00:00-00:00
+    lastmod: 2020-06-06T00:00:00-00:00
 ---
 
 # Deploying to Heroku
 
-This sub-generator allows deployment of your JHipster application to the [Heroku cloud](https://www.heroku.com/).
+This sub-generator allows deployment of your JHipster application to the [Heroku cloud](https://www.heroku.com/){:target="_blank" rel="noopener"}.
 
-[![]({{ site.url }}/images/logo/logo-heroku.png)](https://www.heroku.com/)
+[![]({{ site.url }}/images/logo/logo-heroku.png)](https://www.heroku.com/){:target="_blank" rel="noopener"}
 
 Heroku is helping JHipster in two ways:
 
@@ -22,9 +22,9 @@ Heroku is helping JHipster in two ways:
 
 ## Running the sub-generator
 
-Before running the sub-generator, you must install the [Heroku CLI](https://cli.heroku.com/), and have a Heroku account created.
+Before running the sub-generator, you must install the [Heroku CLI](https://cli.heroku.com/){:target="_blank" rel="noopener"}.
 
-You must also [create a Heroku account](http://signup.heroku.com/) and log in with the CLI by running the following command:
+You must also [create a Heroku account](http://signup.heroku.com/){:target="_blank" rel="noopener"} and log in with the CLI by running the following command:
 
 <pre>**$ heroku login**
 Enter your Heroku credentials.
@@ -33,25 +33,82 @@ Password (typing will be hidden): YOUR_PASSWORD
 Authentication successful.
 </pre>
 
+<div class="alert alert-info"><i class="fa fa-info-circle" aria-hidden="true"></i>
+The Heroku sub-generator will always use free tiers/options. 
+Nevertheless installing addons needs a properly <a href="https://devcenter.heroku.com/articles/account-verification" target="_blank" rel="noopener">verified Heroku account</a>. Therefore to avoid any unexpected build failures, we would recommend verifying your Heroku account before starting this sub-generator.
+</div>
+
+The Heroku sub-generator creates an application using [free dynos](https://devcenter.heroku.com/articles/dyno-types){:target="_blank" rel="noopener"} with add-ons matching your selected configuration.
+
+We support the following addons:
+
+* [Heroku Postgres](https://www.heroku.com/postgres){:target="_blank" rel="noopener"} when using PostgreSQL
+* [JawsDB](https://elements.heroku.com/addons/jawsdb){:target="_blank" rel="noopener"} when using MySQL or MariaDB
+* [mLab MongoDB](https://elements.heroku.com/addons/mongolab){:target="_blank" rel="noopener"} when [using MongoDB](/using-mongodb/)
+* [Graphenedb](https://elements.heroku.com/addons/graphenedb){:target="_blank" rel="noopener"} when [using Neo4j](/using-neo4j/)
+* [Heroku Redis](https://elements.heroku.com/addons/heroku-redis){:target="_blank" rel="noopener"} when [using Redis](/using-cache/#caching-with-redis)
+* [MemCachier](https://elements.heroku.com/addons/memcachier){:target="_blank" rel="noopener"} when [using Memcached](/using-cache/#caching-with-memcached)
+* [Bonsai Elasticsearch](https://elements.heroku.com/addons/bonsai){:target="_blank" rel="noopener"} when [using Elasticsearch](/using-elasticsearch/)
+* [Okta](https://elements.heroku.com/addons/okta){:target="_blank" rel="noopener"} when [using OAuth2/OIDC (optional)](/security/#oauth2)
+
+
 To deploy your application to Heroku, run this command:
 
 `jhipster heroku`
 
 This should package your application in "production" mode, create an Heroku application with a database, upload your code, and start the application.
 
-Depending on your database the sub-generator might install add-ons such as [JawsDB MySQL](https://elements.heroku.com/addons/jawsdb) 
-for MySQL databases. For these addons to be installed properly your [Heroku account needs to be verified](https://devcenter.heroku.com/articles/account-verification).
-Therefore to avoid any unexpected build failures, we would recommend verifying your Heroku account before starting this sub-generator.
-
+<div class="alert alert-info"><i class="fa fa-info-circle" aria-hidden="true"></i>
 Note that if your application is a microservice, you will be prompted to provide a registry URL. Scroll down to learn how to do this.
+</div>
 
-_Please be aware that your application must start under 90 seconds, or it will be shutdown. Depending on the platform load, starting under 90 seconds is not guaranteed!_
+<div class="alert alert-warning"><i class="fa fa-exclamation-circle" aria-hidden="true"></i>
+Please be aware that your application must start under 90 seconds, or it will be shutdown.
+Depending on the platform load, starting under 90 seconds is not guaranteed!
+</div>
 
-## Updating your deployed application
+## Changing the java version
 
-### Preparing a new deployment
+You can select the Java version when executing the Heroku sub-generator.
+By default this will be Java 11.
+You can find all on Heroku [supported Java version in the official documentation](https://devcenter.heroku.com/articles/java-support#supported-java-versions){:target="_blank" rel="noopener"}.
 
-When your application is already deployed, you can prepare a new deployment by typing:
+If you want to change the Java version e.g. from `11` to `14` later you need to change it in `system.properties` in your projects root folder:
+
+```
+java.runtime.version=14
+```
+
+When you redeploy your application it will use Java 14.
+
+## Deploying your application
+
+By default the application will be [deployed via git](https://devcenter.heroku.com/articles/git){:target="_blank" rel="noopener"}.
+This means you push your code and Heroku will build and deploy it on their servers.
+If you can't or don't want to push code to someone else's server you can use the jar option and [deploy an executable jar](https://devcenter.heroku.com/articles/deploying-executable-jar-files){:target="_blank" rel="noopener"}.
+Heroku also supports [deploying a docker image](https://devcenter.heroku.com/articles/container-registry-and-runtime){:target="_blank" rel="noopener"}, but the sub-generator does not support this option yet.
+
+### Updating your deployed application
+
+#### Using git option
+
+When deploying via git a new remote has been created called heroku.
+To deploy new code you need to push the changes to the heroku remote:
+
+`git push heroku master`
+
+<div class="alert alert-info"><i class="fa fa-info-circle" aria-hidden="true"></i>
+This assumes you have run the generator on the machine you are executing this command from.
+If you have not, you will need to follow the <a href="https://devcenter.heroku.com/articles/git#for-an-existing-heroku-app" target="_blank" rel="noopener">instructions for creating a Heroku remote</a>.
+</div>
+
+#### Using jar option
+
+When you selected to deploy an executable jar you need to create the updated jar and deploy the new file to Heroku.
+
+##### Preparing a new jar
+
+When your application is already deployed, you can prepare a new deployment with:
 
 `./mvnw package -Pprod -DskipTests`
 
@@ -59,9 +116,12 @@ Or when using gradle:
 
 `./gradlew -Pprod bootJar -x test`
 
-### Pushing to production
+##### Pushing to production
 
-_Note: This assumes you have run the generator on the machine you are executing this command from. If you have not, you will need to follow the instructions for installing the [Heroku Java CLI](https://devcenter.heroku.com/articles/deploying-executable-jar-files).
+<div class="alert alert-info"><i class="fa fa-info-circle" aria-hidden="true"></i>
+This assumes you have run the generator on the machine you are executing this command from.
+If you have not, you will need to follow the instructions for installing the <a href="https://devcenter.heroku.com/articles/deploying-executable-jar-files" target="_blank" rel="noopener">Heroku Java CLI</a>.
+</div>
 
 To push to production, type:
 
@@ -96,13 +156,55 @@ To use this password, update all of your microservices and your gateway to use t
 
 ## Troubleshooting
 
-If your application is stopped by Heroku when your Liquibase changelog is being applied, your database will be marked as "locked" by Liquibase. You will need to manually clean the lock table. On Postgres, you make sure you have a [local Postgres client installed](https://devcenter.heroku.com/articles/heroku-postgresql#local-setup) and run the following command:
+If your application is stopped by Heroku when your Liquibase changelog is being applied, your database will be marked as "locked" by Liquibase. You will need to manually clean the lock table. On Postgres, you make sure you have a [local Postgres client installed](https://devcenter.heroku.com/articles/heroku-postgresql#local-setup){:target="_blank" rel="noopener"} and run the following command:
 
 `heroku pg:psql -c "update databasechangeloglock set locked=false;"`
 
-Heroku has a default boot-timeout limit of 90 seconds. If your app takes longer than this, Heroku will stop the process, which may leave the database in a locked state. If the problem is persistent, try contacting [Heroku Support](http://help.heroku.com) to request a longer boot limit for your app.
+Heroku has a default boot-timeout limit of 90 seconds. If your app takes longer than this, Heroku will stop the process, which may leave the database in a locked state. If the problem is persistent, try contacting [Heroku Support](http://help.heroku.com){:target="_blank" rel="noopener"} to request a longer boot limit for your app.
+
+### Using Neo4j
+<a name="deploying-microservices"></a>
+As [Graphene DB](https://elements.heroku.com/addons/graphenedb){:target="_blank" rel="noopener"} does not support Neo4j 4.x you can't yet deploy reactive applications with Neo4j to Heroku!
+Beware that the free tier of Graphene DB is quite slow, therefore your application will not feel very snappy.
+
+### Using Elasticsearch
+
+The Bonsai used addon with the free sandbox plan does [only support the latest Elasticsearch version](https://docs.bonsai.io/article/139-which-versions-bonsai-supports){:target="_blank" rel="noopener"}.
+This might lead to some [incompatibilities](https://github.com/jhipster/generator-jhipster/issues/10003){:target="_blank" rel="noopener"} depending in the Spring Data and JHipster versions you are using.
+
+<div class="alert alert-warning"><i class="fa fa-money" aria-hidden="true"></i>
+If you are willing to use a <b>paid plan</b> you can of course select the used Elasticsearch version. <a href="https://github.com/jhipster/generator-jhipster/issues/10003#issuecomment-587770177" target="_blank" rel="noopener">Setting it to e.g. <code class="highlighter-rouge">6.5.4</code> or <code class="highlighter-rouge">`6.6.2</code></a>will work with all JHipster 6.x versions.
+</div>
+
+### Using Okta
+
+When you select [Okta](https://elements.heroku.com/addons/okta){:target="_blank" rel="noopener"} the sub-generator will create a bash script which creates all groups and roles required by JHipster.
+When you login with the user and credentials provided during creation you will need to select a new password as the script makes sure to expire the password directly, 
+as it is stored in `.yo-rc.json`.
+
+<div class="alert alert-info"><i class="fa fa-info-circle" aria-hidden="true"></i>
+The script to provision the Okta addon requires
+<ul>
+  <li><a href="https://curl.haxx.se/" target="_blank" rel="noopener">cURL</a> for web request to the <a href="https://developer.okta.com/docs/reference/" target="_blank" rel="noopener">Okta API</a></li>
+  <li><a href="https://stedolan.github.io/jq/" target="_blank" rel="noopener">jq</a> for parsing/manipulating JSON data</li>
+</ul>
+If it can't find these tools the sub-generator will warn you and you have to execute <code class="highlighter-rouge">./provision-okta-addon.sh</code> manually.
+</div>
+
+### Free dynos
+
+Free dynos are limited and should not be used for production deployment, because
+
+* they fall to sleep after [30 minutes idle period](https://devcenter.heroku.com/articles/free-dyno-hours#dyno-sleeping){:target="_blank" rel="noopener"}
+* they have [limited dyno hours per month](https://devcenter.heroku.com/articles/free-dyno-hours#usage){:target="_blank" rel="noopener"}. When these are consumed your dynos won't run until the next month!
+
+You can upgrade your dyno configuration directly from the Heroku admin ui.
+If you realize e.g. a database plan is too small for you can select a new plan from the admin ui.
+
 
 ## More information
 
-*   [Example Application](https://github.com/kissaten/jhipster-example)
-*   [Spring Boot Heroku documentation](http://docs.spring.io/spring-boot/docs/current/reference/html/cloud-deployment.html#cloud-deployment-heroku)
+*   [Example Application](https://github.com/kissaten/jhipster-example){:target="_blank" rel="noopener"}
+*   [Spring Boot Heroku documentation](https://docs.spring.io/spring-boot/docs/current/reference/html/deployment.html#cloud-deployment-heroku){:target="_blank" rel="noopener"}
+*   [Heroku free dyno documentation](https://devcenter.heroku.com/articles/free-dyno-hours){:target="_blank" rel="noopener"}
+*   [Heroku java support documentation](https://devcenter.heroku.com/articles/java-support#supported-java-versions){:target="_blank" rel="noopener"}


### PR DESCRIPTION
This updates and restructures the Heroku documentation. It adds documentation about the okta, redis, neo4j and memcached options currently in development.

Relates to 

* https://github.com/jhipster/generator-jhipster/pull/11715
* https://github.com/jhipster/generator-jhipster/pull/11712 

This is in draft mode until the next release.