### PR TITLE
add micronaut to offical blueprint listing

### DIFF
--- a/modules/official-blueprints.md
+++ b/modules/official-blueprints.md
@@ -41,3 +41,9 @@ Latest official blueprint, it replaces the server java side with the NestJS Node
 
 Stream lead is: [Angelo Manganiello](https://github.com/amanganiello90).
 
+## Micronaut
+
+Official blueprint supported and driven by people of the [Micronaut team](https://github.com/jhipster/generator-jhipster-micronaut/graphs/contributors) itself.
+It replaces all server side code with a [Micronaut](https://micronaut.io/) application. 
+Source code and documentation can be found here: [repository](https://github.com/jhipster/generator-jhipster-micronaut)
+


### PR DESCRIPTION
Not sure if we consider micronaut an official blueprint (I would say yes). We should add quarkus too imho.