### PR TITLE
Added Lagos, Nigeria Meetup Group

### DIFF
--- a/pages/meetups.md
+++ b/pages/meetups.md
@@ -38,6 +38,10 @@ We are currently creating JHipster meetups all around the world!
 
 - [Dubai, United Arab Emirates - JHipster meetup](https://www.meetup.com/JHipster-Dubai/)
 
+**Africa**
+
+- [Lagos, Nigeria - JHipster meetup](https://www.meetup.com/JHipster-Nigeria/)
+
 ## Meetups being created
 
 *Contact the team if you want to help creating one of those meetups*


### PR DESCRIPTION
We have a JHipster meetup group in Lagos, Nigeria located in Africa region. I added it to the list.