### PR TITLE
add micronaut family member to artwork page

### DIFF
--- a/pages/artwork.md
+++ b/pages/artwork.md
@@ -33,6 +33,7 @@ Below are some examples of the JHipster family members.
   <img src="/jhipster-artwork/family/jhipster_family_member_1.svg" width="200">
   <img src="/jhipster-artwork/family/jhipster_family_member_2.svg" width="200">
   <img src="/jhipster-artwork/family/jhipster_family_member_3.svg" width="200">
+  <img src="/jhipster-artwork/family/jhipster_family_member_4.svg" width="200">
 </div>
 
 ## Inclusiveness


### PR DESCRIPTION
This adds the micronaut family member to the artwork page. I can't find the files in the local repository I guess there is a redirect/configuration to our artwork repo somewhere, is that correct?