### PR TITLE
correct entando footer image link

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -401,7 +401,7 @@
                                     <div class="col-sm-12 col-md-4">
                                         <div class="thumbnail no-margin-bottom">
                                             <div class="logo-container">
-                                                <a href="https://dev.entando.org/jhipster" target="_blank" rel="noopener"><img src="{{ site.url }}/images/open-collective/Entando_E.png" width="180px" height="175px"></a>
+                                                <a href="https://dev.entando.org/jhipster" target="_blank" rel="noopener"><img src="{{ site.url }}/images/open-collective/entandoe.png" width="180px" height="175px"></a>
                                             </div>
                                             <div class="caption">
                                                 <a href="https://dev.entando.org/jhipster" target="_blank" rel="noopener">Micro Frontend Platform for Kubernetes</a>


### PR DESCRIPTION
This PR corrects the entando image in the page footer.

Current state

![image](https://user-images.githubusercontent.com/203401/95177767-e1e51700-07be-11eb-83ea-5d2af957c581.png)

Correct:
![image](https://user-images.githubusercontent.com/203401/95177861-fd502200-07be-11eb-9240-d39e4fc697a8.png)


