### PR TITLE
Fixed reflexive relationship example

### DIFF
--- a/pages/jdl/relationships.md
+++ b/pages/jdl/relationships.md
@@ -198,7 +198,7 @@ A reflexive relationship is a relationship whose source & destination entities a
 
 ```jdl
 relationship ManyToMany {
-  A{parent required} to A{child}
+  A{parent} to A{child}
 }
 ```
 


### PR DESCRIPTION
A reflexive relationship can never have a required side. There was already a note about that limitation, but the example still had the `required` keyword.

See discussion in https://github.com/jhipster/generator-jhipster/issues/11495