### PR TITLE
The example code may be wrong in "Do not use  `@MapsId`"

### DIFF
--- a/pages/managing_relationships.md
+++ b/pages/managing_relationships.md
@@ -422,8 +422,8 @@ Do not use  `@MapsId` when:
     For eg,
 
     ```
-    class Car{ @OneToOne @JoinColumn(name="id") Driver currentDriver} // car can be drived by another driver in future
-    class Driver{@OneToOne @JoinColumn(name="id") Car drivingCar} // driver drives another car in future
+    class Car{ @OneToOne @JoinColumn(name="current_driver_id") Driver currentDriver} // car can be drived by another driver in future
+    class Driver{@OneToOne(mappedBy = "currentDriver") Car drivingCar} // driver drives another car in future
     ```
     Both car and driver association value may change in future.
 


### PR DESCRIPTION
I think the example code in "Do not use `@MapsId`" may be wrong.
If it's a bidirectional one-to-one, may be it should be like what I have edited，like this
```
class Car{ @OneToOne @JoinColumn(name="current_driver_id") Driver currentDriver} // car can be drived by another driver in future
class Driver{@OneToOne(mappedBy = "currentDriver") Car drivingCar} // driver drives another car in future
```
if they're two unidirectional one-to-one, maybe 'id' shouldn't be the join column I think.

I'm not native speaker of English, so please point out if I say something wrong.

Thanks