### PR TITLE
Updating Oracle database limitations per version and Docker images information.

### DIFF
--- a/pages/using_oracle.md
+++ b/pages/using_oracle.md
@@ -6,22 +6,36 @@ redirect_from:
   - /using_oracle.html
 sitemap:
     priority: 0.7
-    lastmod: 2015-06-08T18:40:00-00:00
+    lastmod: 2021-01-08T09:40:00-00:00
 ---
 
 # <i class="fa fa-database"></i> Using Oracle
 
 When using JPA, you have the option to use the Oracle database.
 
-_This option is only supported with Oracle 12c and upwards._
+_This option is only supported with Oracle 12cR1 and upwards (e.g. 19c, 18c and 12cR2)._
 
-When using Oracle with JHipster, the following limitations will be applicable
+When using Oracle with JHipster, the following limitations will be applicable according to the Oracle database version.
 
+For version 19c, 18c and 12cR2:
+- Entity names cannot be more than 124 characters, this is due to Oracle's 128 character limitation for object names, and we reserve 4 characters to generate primary key sequence for the generated tables.
+- Entity field names cannot be more than 128 characters.
+- When doing relationships, foreign key names cannot be more than 128 characters, so they will be truncated if they are too long.
+- When doing many-to-many relationships, the join table name will follow the JPA specification (in the form "firstTable_secondTable"): if it is more than 128 characters long, it will be truncated.
+
+For version 12cR1:
 - Entity names cannot be more than 26 characters, this is due to Oracle's 30 character limitation for object names, and we reserve 4 characters to generate primary key sequence for the generated tables.
 - Entity field names cannot be more than 30 characters.
 - When doing relationships, foreign key names cannot be more than 30 characters, so they will be truncated if they are too long.
 - When doing many-to-many relationships, the join table name will follow the JPA specification (in the form "firstTable_secondTable"): if it is more than 30 characters long, it will be truncated.
+
 - Oracle reserved keywords cannot be used as Entity names or Field names.
-- We do not provide an Oracle database Docker image, like we do for other databases, as Oracle does not allow to have public Docker images.
+
+- Oracle database 19c (EE, SE2, Single Instance and RAC) Docker images can be found here: https://container-registry.oracle.com
+- Oracle database 19c Docker build files can be found here: https://github.com/oracle/docker-images/tree/master/OracleDatabase
+
+
+Note that version 19c is highly recommended because it has Long Term Support (ending in 2027).
+
 
 <br/><br/><br/><br/><br/><br/><br/><br/><br/><br/>


### PR DESCRIPTION
JHipster documentation about the Oracle database is old and misleading. I fixed the name length limitations. I also added more accurate information regarding the official Oracle database docker images.

Thanks
Loïc