### PR TITLE
correct okta cli usage command

### DIFF
--- a/pages/security.md
+++ b/pages/security.md
@@ -115,7 +115,7 @@ If you'd like to use Okta instead of Keycloak, it's pretty quick using the [Okta
 okta register
 ```
 
-Then, in your JHipster app's directory, run `okta apps create` and select **JHipster**. This will set up an Okta app for you, create `ROLE_ADMIN` and `ROLE_USER` groups, create a `.okta.env` file with your Okta settings, and configure a `groups` claim in your ID token.
+Then, in your JHipster app's directory, run `okta apps create jhipster`. This will set up an Okta app for you, create `ROLE_ADMIN` and `ROLE_USER` groups, create a `.okta.env` file with your Okta settings, and configure a `groups` claim in your ID token.
 
 Run `source .okta.env` and start your app with Maven or Gradle. You should be able to sign in with the credentials you registered with.
 


### PR DESCRIPTION
When trying out okta cli it did not work as described. I only got the following options:

```
➜ okta apps create
Application name [okta-cypress]: 
Type of Application
(The Okta CLI only supports a subset of application types and properties):
> 1: Web
> 2: Single Page App
> 3: Native App (mobile)
> 4: Service (Machine-to-Machine)
Enter your choice [Web]:
```

Doing `okta apps create jhipster` works. Looking at the cli code this seems correct (https://github.com/okta/okta-cli/blob/master/cli/src/main/java/com/okta/cli/commands/apps/templates/AppType.java) as jhipster is quick template.