### PR TITLE
Fix Twitter image

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -10,7 +10,7 @@
     <meta name="twitter:site" content="@jhipster" />
     <meta name="twitter:title" content="JHipster - Full Stack Platform for the Modern Developer!" />
     <meta name="twitter:description" content="JHipster is a development platform to quickly generate, develop, and deploy modern web applications + microservice architectures." />
-    <meta name="twitter:image:src" content="https://www.jhipster.tech/images/twitter-card.png?20210212" />
+    <meta name="twitter:image" content="https://www.jhipster.tech/images/twitter-card.png?20210212" />
     <meta name="twitter:url" content="https://www.jhipster.tech/" />{% endif %}
     <meta name="google-site-verification" content="JSA7VC5gSwD5KKbXlxK8F9rXJtC91rKJq0aWhfpBC0k" />
     <!-- Chrome, Firefox OS and Opera -->


### PR DESCRIPTION
If I use Twitter's [card validator](https://cards-dev.twitter.com/validator), it shows an error for jhipster.tech. 

<img width="1016" alt="Screen Shot 2021-02-12 at 10 42 10 AM" src="https://user-images.githubusercontent.com/17892/107802853-19407300-6d1f-11eb-9055-268ddc9fb9ec.png">

According to [Twitter's card docs](https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/summary-card-with-large-image), the meta name should be `twitter:image`, not `twitter:image:src`.