### PR TITLE
Added "See also" sections to the JDL app options and regular options pages

### DIFF
--- a/pages/jdl/applications.md
+++ b/pages/jdl/applications.md
@@ -21,6 +21,7 @@ sitemap:
 1. [Microservice workflow](#microservice-workflow)
 1. [Complete example breakdowns](#complete-example-breakdowns)
 1. [Available application configuration options](#available-application-configuration-options)
+1. [See also](#see-also)
 
 ***
 
@@ -359,6 +360,8 @@ You can also create an entire microservice stack using JDL, [see this blog post]
 
 Here are the application options supported in the JDL:
 
+_Not what you're looking for? Check the [regular options](/jdl/options#available-options)._
+
 <table class="table table-striped table-responsive">
   <tr>
     <th>JDL option name</th>
@@ -571,3 +574,9 @@ Here are the application options supported in the JDL:
     <td></td>
   </tr>
 </table>
+
+---
+
+### See also
+
+The regular options are available [here](/jdl/options)

--- a/pages/jdl/options.md
+++ b/pages/jdl/options.md
@@ -46,6 +46,7 @@ The complete list of available options is [here](#available-options).
 1. [Microservice-related options](#microservice-related-options)
 1. [Custom annotations](#custom-annotations)
 1. [Available options](#available-options)
+1. [See also](#see-also)
 
 ---
 
@@ -403,6 +404,8 @@ However, for custom options, they will be generated under and `options` key in t
 
 Here are the entity options supported in the JDL:
 
+_Not what you're looking for? Check the [application options](/jdl/applications#available-application-configuration-options)._
+
 <table class="table table-striped table-responsive">
   <tr>
     <th>JDL option name</th>
@@ -506,3 +509,9 @@ Here are the entity options supported in the JDL:
     <td></td>
   </tr>
 </table>
+
+---
+
+### See also
+
+The application options are available [here](/jdl/applications)


### PR DESCRIPTION
The goal here is to fix a potential user confusion where she/he lands on an unexpected page when looking for options.

---

![image](https://user-images.githubusercontent.com/2753381/109866136-33f27180-7c65-11eb-903f-46d86988b98f.png)

![image](https://user-images.githubusercontent.com/2753381/109866180-42d92400-7c65-11eb-9166-307599dd61fd.png)

![image](https://user-images.githubusercontent.com/2753381/109866205-4a98c880-7c65-11eb-8c09-640796e5601b.png)

---

Fixes https://github.com/jhipster/generator-jhipster/issues/14146