### PR TITLE
JHipster App is deprecated

### DIFF
--- a/pages/configuring-ide-visual-studio-code.md
+++ b/pages/configuring-ide-visual-studio-code.md
@@ -37,8 +37,8 @@ The Visual Studio Code Java extension can't be used to run commands: it can't co
 
 For all those tasks, there are 2 solutions:
 
-- Use the [JHipster App]({{ site.url }}/jhipster-app), which offers a graphical interface for all those commands
 - Use the terminal, for instance the internal terminal provided by Visual Studio Code, to run those commands manually
+- Use the [JHipster App]({{ site.url }}/jhipster-app), which offers a graphical interface for all those commands. **Note:** JHipster App is deprecated.
 
 ## Application "hot restart" with Spring Boot devtools
 


### PR DESCRIPTION
JHipster App is deprecated. I have changed the order of the items, using the terminal should be the preferred way.
Other possibility is just remove all references to JHipster App.
