### PR TITLE
Remove repeated 'a' article from problem-with-message.md

### DIFF
--- a/pages/problem/problem-with-message.md
+++ b/pages/problem/problem-with-message.md
@@ -11,7 +11,7 @@ sitemap:
 
 You probably found this page by clicking on an error message in an application that was developed with JHipster.
 
-JHipster is a an application generator, which was used to develop the application you are using. You can find more information about JHipster by going to our [home page]({{ site.url }}).
+JHipster is an application generator, which was used to develop the application you are using. You can find more information about JHipster by going to our [home page]({{ site.url }}).
 
 Please find below some information on the error that happened.
 


### PR DESCRIPTION
[This page](https://www.jhipster.tech/problem/problem-with-message/) currently has a phrase starting with `JHipster is a an application [...]`, while it should be `JHipster is an application [...]`.