### PR TITLE
Adds extra step in instruction for Database updates with the Maven liquibase:diff goal

### DIFF
--- a/pages/development.md
+++ b/pages/development.md
@@ -197,6 +197,7 @@ If you are running H2 with disk-based persistence, this workflow is not yet work
 Here is the development workflow:
 
 *   Modify your JPA entity (add a field, a relationship, etc.)
+*   Skip changes in the re-generated liquibase file for that entity `config/liquibase/changelog/DATE_added_entity_ENTITY_NAME.xml` to avoid conflict with the soon to be generated changelog file bellow
 *   Compile your application (this works on the compiled Java code, so don't forget to compile!)
 *   Run `./mvnw liquibase:diff` (or `./mvnw compile liquibase:diff` to compile before)
 *   A new "change log" is created in your `src/main/resources/config/liquibase/changelog` directory


### PR DESCRIPTION
I want to propose an addition to the Documentation, specifically to

https://www.jhipster.tech/development/ , section:
	Modify your JPA entity (add a field, a relationship, etc.)

If you modify your entity, for example, you add a new field, then, the new field is added to the

config/liquibase/changelog/DATE_added_entity_ENTITY_NAME.xml

So when the liquibase:diff goal is called, and a new changelog is added such as

```
<changeSet author="poolebu (generated)" id="1618764540135-3" >
    <addColumn tableName="ENTITY_NAME">
        <column name="NEW_COLUMN" type="bit" defaultValueBoolean="true"/>
    </addColumn>
</changeSet>
```

Then the changesets conflict.

This commit has my proposal of adding an extra step to the instructions for using the workflow.