### PR TITLE
Block strange blueprint generator-jhipster-yob

### DIFF
--- a/modules/marketplace/data/modules-config.json
+++ b/modules/marketplace/data/modules-config.json
@@ -14,6 +14,7 @@
         "generator-jhipster-botw-theme" : true,
         "generator-jhipster-elasticsearch-rest-client" : true,
         "jhipster-omnivue" : true,
-        "generator-jhipster-omnivue" : true
+        "generator-jhipster-omnivue" : true,
+        "generator-jhipster-yob" : true
     }
 }


### PR DESCRIPTION
On npm, https://www.npmjs.com/package/generator-jhipster-yob shows a default generated blueprint with wrong github repo: https://github.com/mygitname/generator-jhipster-yob

```json
  "author": {
    "name": "mygitfirstname mygitlastname",
    "email": "mygitemail",
    "url": "mygiturl"
  },
  "bugs": {
    "url": "https://github.com/mygitname/generator-jhipster-yob/issues"
  },
```

However, the page mentions a github user @alankarapte as the author.

I don't necessarily think it's malicious intent, it could be someone who made an experimental blueprint and forgot to cleanup on npm.

Let's block it from being displayed in JHipster Market Place

Fix https://github.com/jhipster/generator-jhipster/issues/14813