### PR TITLE
Change extension from .jh to .jdl on index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -105,8 +105,8 @@ sitemap:
                         <li>Install JHipster <code>npm install -g generator-jhipster</code></li>
                         <li>Create a new directory and go into it <code>mkdir myApp &amp;&amp; cd myApp</code></li>
                         <li>Run JHipster and follow instructions on screen <code>jhipster</code></li>
-                        <li>Model your entities with <a href="https://start.jhipster.tech/jdl-studio/" target="_blank" rel="noopener">JDL Studio</a> and download the resulting <code>jhipster-jdl.jh</code> file</li>
-                        <li>Generate your entities with <code>jhipster jdl jhipster-jdl.jh</code></li>
+                        <li>Model your entities with <a href="https://start.jhipster.tech/jdl-studio/" target="_blank" rel="noopener">JDL Studio</a> and download the resulting <code>jhipster-jdl.jdl</code> file</li>
+                        <li>Generate your entities with <code>jhipster jdl jhipster-jdl.jdl</code></li>
                     </ol>
                 </div>
             </div>


### PR DESCRIPTION
As JDL-studio downloads .jdl files, the steps are changed accordingly

Relates to jhipster/generator-jhipster#16425