### PR TITLE
Fix proxy URL for npm-registry proxy call

### DIFF
--- a/js/services.js
+++ b/js/services.js
@@ -53,7 +53,7 @@
             },
 
             getNpmInfo: function (npmPackageName) {
-                return $http.get('https://cors.bridged.cc/registry.npmjs.org/' + npmPackageName + '/latest').success(function (resp) {
+                return $http.get('https://cors.bridged.cc/https://registry.npmjs.org/' + npmPackageName + '/latest').success(function (resp) {
                     return resp;
                 });
             }


### PR DESCRIPTION
The API on marketplace details page to fetch package details has stopped working due to change in CORS proxy. It needs to include protocol now.
![image](https://user-images.githubusercontent.com/6285049/134850949-a9d0c15e-3e5e-48c8-a949-ea1a226be4a6.png)

Maybe in future we can use netlify rewrites to have own proxy url instead of using an external one.

Proxy request via cors.bridged.cc changed to include protocol as
requirement