### PR TITLE
removed Create a static Swagger API documentation

### DIFF
--- a/pages/tips.md
+++ b/pages/tips.md
@@ -15,7 +15,6 @@ This section contains **user-submitted tips'n tricks** on using JHipster.
 
 _If you want to contribute, don't hesitate to send us a Pull Request with your tips on our [GitHub repository](https://github.com/jhipster/jhipster.github.io)._
 
-1. [Create a static Swagger API documentation]({{ site.url }}/tips/008_tips_static_swagger_docs.html)
 1. [Using Bootswatch themes]({{ site.url }}/tips/009_tips_using_bootswatch_themes.html)
 1. [Configuring Email with - Gmail and more]({{ site.url }}/tips/011_tip_configuring_email_in_jhipster.html)
 1. [Speed up the generator-jhipster]({{ site.url }}/tips/013_tip_speed_up_generator.html)


### PR DESCRIPTION
The swagger2markup generator hasn't been updated for years, and according to the issue below (2019), it's not working with jhipster 5.
https://github.com/atomfrede/generator-jhipster-swagger2markup/issues/27
I propose to remove this tip that is now updated.