### PR TITLE
Update docker_compose.md

### DIFF
--- a/pages/docker_compose.md
+++ b/pages/docker_compose.md
@@ -102,8 +102,10 @@ With Maven, type: <pre>./mvnw -Pprod package verify jib:dockerBuild --offline</p
 With Gradle, type: <pre>./gradlew -Pprod bootJar jibDockerBuild --offline</pre>
 </p>
 <p>
-If jib has not already pulled the base Docker image in its cache, to do it, you need to modify the pom.xml by adding `docker://` as prefix of your base image.
-Example <pre><from>docker://imagename:latest</pre>
+If jib has not already pulled the base Docker image in its cache, to do it, you need to modify the pom.xml (in case of Maven) or the docker.gradle (in case of Gradle) by adding `docker://` as prefix of your base image (at the "image" tag, nested in the "from" tag).
+</p>
+<p>
+Example: <pre>docker://imagename:latest</pre>
 In this way jib puts the image present in your local docker daemon in its cache.
 </p>
 </div>

--- a/pages/docker_compose.md
+++ b/pages/docker_compose.md
@@ -102,7 +102,9 @@ With Maven, type: <pre>./mvnw -Pprod package verify jib:dockerBuild --offline</p
 With Gradle, type: <pre>./gradlew -Pprod bootJar jibDockerBuild --offline</pre>
 </p>
 <p>
-Note that jib is currently unable to pull a local Docker image from the Docker daemon. Progress on this issue is tracked at [GoogleContainerTools/jib/issues/1468](https://github.com/GoogleContainerTools/jib/issues/1468).
+If jib has not already pulled the base Docker image in its cache, to do it, you need to modify the pom.xml by adding `docker://` as prefix of your base image.
+Example <pre><from>docker://imagename:latest</pre>
+In this way jib puts the image present in your local docker daemon in its cache.
 </p>
 </div>
 


### PR DESCRIPTION
JIB is able to build the image starting from an image present in our local registry, it just need to explicitly say to pull this image from the local docker registry, then jib will transform it in jib format and cache it.