### PR TITLE
Update broken reference to Spring Cloud Feign documentation

### DIFF
--- a/pages/doing_api_first_development.md
+++ b/pages/doing_api_first_development.md
@@ -98,7 +98,7 @@ When using IntelliJ
 
 ### Using the `openapi-client` Sub-Generator
 
-JHipster also provides support for generation of client code using [Spring-Cloud FeignClients](https://projects.spring.io/spring-cloud/spring-cloud.html#spring-cloud-feign) or Spring Webclient for reactive apps using an OpenAPI/Swagger specification.
+JHipster also provides support for generation of client code using [Spring Cloud OpenFeign](https://docs.spring.io/spring-cloud-openfeign/docs/current/reference/html/) or Spring Webclient for reactive apps using an OpenAPI/Swagger specification.
 The generated Client can be used in both Monolithic and Micro-service applications and supports Swagger v2 and OpenAPI v3 definitions. To invoke this sub-generator run `jhipster openapi-client`.
 
 


### PR DESCRIPTION
Update broken reference to [Spring Cloud Feign documentation](https://docs.spring.io/spring-cloud-openfeign/docs/current/reference/html/)