### PR TITLE
Change adoptopenjdk.net to adoptium.net

### DIFF
--- a/index.html
+++ b/index.html
@@ -99,7 +99,7 @@ sitemap:
                 <div class="col-lg-12">
                     <ol class="text-body">
                         <li>Install
-                            <a href="https://adoptopenjdk.net/" target="_blank" rel="noopener">Java</a>,
+                            <a href="https://adoptium.net/temurin/releases/?version=11" target="_blank" rel="noopener">Java</a>,
                             <a href="http://git-scm.com/" target="_blank" rel="noopener">Git</a> and
                             <a href="http://nodejs.org/" target="_blank">Node.js</a></li>
                         <li>Install JHipster <code>npm install -g generator-jhipster</code></li>

--- a/pages/installation.md
+++ b/pages/installation.md
@@ -34,7 +34,7 @@ In the future, we expect JHipster Online to provide more features.
 
 ### Quick setup
 
-1.  Install Java 11. We recommend you use [AdoptOpenJDK builds](https://adoptopenjdk.net/), as they are open source and free.
+1.  Install Java 11. We recommend you use [Eclipse Temurin builds](https://adoptium.net/temurin/releases/?version=11), as they are open source and free.
 2.  Install Node.js from [the Node.js website](http://nodejs.org/) (please use an LTS 64-bit version, non-LTS versions are not supported)
 3.  Install JHipster: `npm install -g generator-jhipster`
 4.  (optional) If you want to use a module or a blueprint (for instance from the [JHipster Marketplace]({{ site.url }}/modules/marketplace/#/list)), install [Yeoman](https://yeoman.io/): `npm install -g yo`


### PR DESCRIPTION
adoptopenjdk.net has a notice on their site that they have moved to adoptium.net
I've updated the links for downloading java accordingly