### PR TITLE
add idea jdl plugin

### DIFF
--- a/index.html
+++ b/index.html
@@ -347,6 +347,7 @@ sitemap:
                     <div>
                         <h3>News</h3>
                         <ul>
+                            <li><b>The JHipster IntelliJ Plugin</b> is available! Download it for free from <a href="https://plugins.jetbrains.com/plugin/19697-jhipster-jdl" target="_blank" rel="noopener">jetbrains plugin registry</a>.</li>
                             <li><b>The JHipster Developers Association</b> now hosts <b>Virtual Meetups</b> on its <a href="https://www.youtube.com/c/JHipsterDevelopersAssociation">Youtube Channel</a>.</li>
                             <li><b>Full Stack Development with JHipster - Second edition</b> by Deepu K Sasidharan and Sendil Kumar is published. Get it on <a href="https://www.packtpub.com/web-development/full-stack-development-with-jhipster-second-edition" target="_blank" rel="noopener">Packt</a> and <a href="https://smile.amazon.com/Full-Stack-Development-JHipster-microservices/dp/1838824987" target="_blank" rel="noopener">Amazon</a>. Get 25% discount on E-books from Amazon and Packt using discount code "25JAVASILVER". Valid until 1st of July 2020</li>
                             <li><b>The JHipster Mini-Book 5.0</b> by Matt Raible is now available! Download it for free from <a href="https://www.infoq.com/minibooks/jhipster-mini-book-5" target="_blank" rel="noopener">InfoQ</a> or buy the print version <a href="http://www.lulu.com/shop/matt-raible/the-jhipster-mini-book/paperback/product-23871310.html">from Lulu</a>.</li>

--- a/pages/jdl/intro.md
+++ b/pages/jdl/intro.md
@@ -16,6 +16,7 @@ their relationships in a single file (or more than one) with a user-friendly syn
 
 You can use our online [JDL-Studio](https://start.jhipster.tech/jdl-studio/) or one of the 
 [JHipster IDE](https://www.jhipster.tech/jhipster-ide/) plugins/extensions, which are available for:
+  - [IntelliJ](https://plugins.jetbrains.com/plugin/19697-jhipster-jdl)
   - [Eclipse](https://marketplace.eclipse.org/content/jhipster-ide), 
   - [VS Code](https://marketplace.visualstudio.com/items?itemName=jhipster-ide.jdl)
 


### PR DESCRIPTION
We should promote the plugin. For now I have just put it under news and the jdl introduction (although I guess its not exactly a jhipster-ide plugin from a technical point of view.