### PR TITLE
Update and re-order blueprints by stars

### DIFF
--- a/modules/official-blueprints.md
+++ b/modules/official-blueprints.md
@@ -66,7 +66,7 @@ Stream lead is [Frederik Hahne](https://github.com/atomfrede).
 
 ## Svelte
 
-The Svelte blueprint replaces the client with Svelete. Source code and documentation could be found in the [generator-jhipster-svelte](https://github.com/jhipster/generator-jhipster-svelte) repository. {⭐️: 44}
+The Svelte blueprint replaces the client-side code with the SvelteKit framework. Source code and documentation could be found in the [generator-jhipster-svelte](https://github.com/jhipster/generator-jhipster-svelte) repository. {⭐️: 44}
 
 Stream lead is: [Vishal Mahajan](https://github.com/vishal423).
 

--- a/modules/official-blueprints.md
+++ b/modules/official-blueprints.md
@@ -12,42 +12,68 @@ sitemap:
 
 # <i class="fa fa-star"></i> Officially supported blueprints
 
-JHipster supports several official blueprints. These blueprints have two main goals:
+The JHipster team maintains several official blueprints. These blueprints have two main goals:
 
 * Enhance JHipster with new features using different languages and/or support
 * Demonstrate how the main generator behavior can be modified to fit anyone's needs
 
+The blueprints below are ordered by the number of stars they have on GitHub. 
+
+{:toc}
+
 ## Kotlin
 
-It replaces most of Java back-end code with Kotlin. Source code and documentation could be found here: [repository](https://github.com/jhipster/jhipster-kotlin).
+The Kotlin blueprint replaces most of Java back-end code with Kotlin. Source code and documentation could be found in the [jhipster-kotlin](https://github.com/jhipster/jhipster-kotlin) repository. {⭐️: 411}
 
 Stream lead is: [Sendil Kumar](https://github.com/sendilkumarn).
 
-## Vue.js
+## .NET Core
 
-It replaces the whole front-end logic with Vue.js. Source code and documentation could be found here: [repository](https://github.com/jhipster/jhipster-vuejs).
-
-Stream lead is: [Sahbi Ktifa](https://github.com/sahbi-ktifa).
-
-## .Net
-
-This is the first attempt to leave the Java environment and join .Net world. Source code and documentation could be found here: [repository](https://github.com/jhipster/jhipster-dotnetcore).
+The .NET Core blueprint is the first attempt to leave the Java environment and join the .NET world. Source code and documentation could be found in the [jhipster-dotnetcore](https://github.com/jhipster/jhipster-dotnetcore) repository. {⭐️: 249}
 
 Stream lead is: [Daniel Petisme](https://github.com/danielpetisme).
 
+## React Native
+
+The React Native blueprint creates a client application with React Native. Source code and documentation could be found in the [generator-jhipster-react-native](https://github.com/jhipster/generator-jhipster-react-native) repository. {⭐️: 235}
+
+Stream lead is: [Jon Ruddell](https://github.com/ruddell).
+
 ## Node.js
 
-It replaces the server java side with the NestJS Node framework. Source code and documentation could be found here: [repository](https://github.com/jhipster/generator-jhipster-nodejs).
+The Node.js blueprint replaces the server java side with the NestJS Node framework. Source code and documentation could be found in the [generator-jhipster-nodejs](https://github.com/jhipster/generator-jhipster-nodejs) repository. {⭐️: 223}
 
 Stream lead is: [Angelo Manganiello](https://github.com/amanganiello90).
 
-## Micronaut
+## Ionic
 
-This blueprint supported and driven by people of the [Micronaut team](https://github.com/jhipster/generator-jhipster-micronaut/graphs/contributors) itself.
-It replaces all server side code with a [Micronaut](https://micronaut.io/) application. 
-Source code and documentation can be found here: [repository](https://github.com/jhipster/generator-jhipster-micronaut)
+The Ionic blueprint creates a client application with Ionic. Source code and documentation could be found in the [generator-jhipster-ionic](https://github.com/jhipster/generator-jhipster-ionic) repository. {⭐️: 170}
+
+Stream lead is: [Matt Raible](https://github.com/mraible).
 
 ## Quarkus
 
-This blueprint supported, in part by the JHipster sponsor [Entando](https://www.entando.com/), and driven by the JHipster community for a [supersonic, subatomic Java back-end](https://quarkus.io/).
-Source code and documentation can be found here: [repository](https://github.com/jhipster/generator-jhipster-quarkus)
+The Quarkus blueprint is supported, in part by the JHipster sponsor [Entando](https://www.entando.com/), and driven by the JHipster community for a [supersonic, subatomic Java back-end](https://quarkus.io/).
+Source code and documentation can be found in the [generator-jhipster-quarkus](https://github.com/jhipster/generator-jhipster-quarkus) repository. {⭐️: 111}
+
+Stream lead is [Anthony Viard](https://github.com/avdev4j).
+
+## Micronaut
+
+The Micronaut blueprint is supported and driven by people of the [Micronaut team](https://github.com/jhipster/generator-jhipster-micronaut/graphs/contributors) itself.
+It replaces all server side code with a [Micronaut](https://micronaut.io/) application.
+Source code and documentation can be found in the [generator-jhipster-micronaut](https://github.com/jhipster/generator-jhipster-micronaut) repository. {⭐️: 91}
+
+Stream lead is [Frederik Hahne](https://github.com/atomfrede).
+
+## Svelte
+
+The Svelte blueprint replaces the client with Svelete. Source code and documentation could be found in the [generator-jhipster-svelte](https://github.com/jhipster/generator-jhipster-svelte) repository. {⭐️: 44}
+
+Stream lead is: [Vishal Mahajan](https://github.com/vishal423).
+
+## JHipster Native
+
+The JHipster Native blueprint integrates Spring Native, making it possible to create a native binary with GraalVM. Source code and documentation could be found in the [generator-jhipster-native](https://github.com/jhipster/generator-jhipster-native) repository. {⭐️: 28}
+
+Stream lead is: [Marcelo Shima](https://github.com/mshima).

--- a/modules/official-blueprints.md
+++ b/modules/official-blueprints.md
@@ -21,69 +21,89 @@ The blueprints below are ordered by the number of stars they have on GitHub.
 
 ## Kotlin
 
-The Kotlin blueprint replaces most of Java back-end code with Kotlin. Source code and documentation could be found in the [jhipster-kotlin](https://github.com/jhipster/jhipster-kotlin) repository. {⭐️: 411}
+The Kotlin blueprint replaces most of Java back-end code with Kotlin. 
 
-Stream lead: [Sendil Kumar](https://github.com/sendilkumarn)
+- Code and docs: [jhipster/jhipster-kotlin](https://github.com/jhipster/jhipster-kotlin)
+- GitHub ⭐️: 411
+- Stream lead: [Sendil Kumar](https://github.com/sendilkumarn)
 
 ## .NET Core
 
-The .NET Core blueprint is the first attempt to leave the Java environment and join the .NET world. Source code and documentation could be found in the [jhipster-dotnetcore](https://github.com/jhipster/jhipster-dotnetcore) repository. {⭐️: 249}
+The .NET Core blueprint is the first attempt to leave the Java environment and join the .NET world. 
 
-Stream lead: [Daniel Petisme](https://github.com/danielpetisme)
+- Code and docs: [jhipster/jhipster-dotnetcore](https://github.com/jhipster/jhipster-dotnetcore)
+- GitHub ⭐️: 249
+- Stream lead: [Daniel Petisme](https://github.com/danielpetisme)
 
 ## React Native
 
-The React Native blueprint creates a client application with React Native. Source code and documentation could be found in the [generator-jhipster-react-native](https://github.com/jhipster/generator-jhipster-react-native) repository. {⭐️: 235}
+The React Native blueprint creates a client application with React Native. 
 
-Stream lead: [Jon Ruddell](https://github.com/ruddell)
+- Code and docs: [jhipster/generator-jhipster-react-native](https://github.com/jhipster/generator-jhipster-react-native)
+- GitHub ⭐️: 235
+- Stream lead: [Jon Ruddell](https://github.com/ruddell)
 
 ## Node.js
 
-The Node.js blueprint replaces the server java side with the NestJS Node framework. Source code and documentation could be found in the [generator-jhipster-nodejs](https://github.com/jhipster/generator-jhipster-nodejs) repository. {⭐️: 223}
+The Node.js blueprint replaces the server java side with the NestJS Node framework. 
 
-Stream lead: [Angelo Manganiello](https://github.com/amanganiello90)
+- Code and docs: [jhipster/generator-jhipster-nodejs](https://github.com/jhipster/generator-jhipster-nodejs)
+- GitHub ⭐️: 223
+- Stream lead: [Angelo Manganiello](https://github.com/amanganiello90)
 
 ## Ionic
 
-The Ionic blueprint creates a client application with Ionic. Source code and documentation could be found in the [generator-jhipster-ionic](https://github.com/jhipster/generator-jhipster-ionic) repository. {⭐️: 170}
+The Ionic blueprint creates a client application with Ionic. 
 
-Stream lead: [Matt Raible](https://github.com/mraible)
+- Code and docs: [jhipster/generator-jhipster-ionic](https://github.com/jhipster/generator-jhipster-ionic)
+- GitHub ⭐️: 171
+- Stream lead: [Matt Raible](https://github.com/mraible)
 
 ## Quarkus
 
 The Quarkus blueprint is supported, in part by the JHipster sponsor [Entando](https://www.entando.com/), and driven by the JHipster community for a [supersonic, subatomic Java back-end](https://quarkus.io/).
-Source code and documentation can be found in the [generator-jhipster-quarkus](https://github.com/jhipster/generator-jhipster-quarkus) repository. {⭐️: 111}
 
-Stream lead: [Anthony Viard](https://github.com/avdev4j)
+- Code and docs: [jhipster/generator-jhipster-quarkus](https://github.com/jhipster/generator-jhipster-quarkus)
+- GitHub ⭐️: 111
+- Stream lead: [Anthony Viard](https://github.com/avdev4j)
 
 # Entity Audit
 
-The Entity Audit blueprint integrates Javers for entity auditing. Source code and documentation can be found in the [generator-jhipster-entity-audit](https://github.com/hipster-labs/generator-jhipster-entity-audit) repository. {⭐️: 107}
+The Entity Audit blueprint integrates Javers for entity auditing. 
 
-Stream lead: [Marcelo Shima](https://github.com/mshima)
+- Code and docs: [hipster-labs/generator-jhipster-entity-audit](https://github.com/hipster-labs/generator-jhipster-entity-audit)
+- GitHub ⭐️: 107
+- Stream lead: [Marcelo Shima](https://github.com/mshima)
 
 ## Micronaut
 
 The Micronaut blueprint is supported and driven by people of the [Micronaut team](https://github.com/jhipster/generator-jhipster-micronaut/graphs/contributors) itself.
 It replaces all server side code with a [Micronaut](https://micronaut.io/) application.
-Source code and documentation can be found in the [generator-jhipster-micronaut](https://github.com/jhipster/generator-jhipster-micronaut) repository. {⭐️: 91}
 
-Stream lead: [Frederik Hahne](https://github.com/atomfrede)
+- Code and docs: [jhipster/generator-jhipster-micronaut](https://github.com/jhipster/generator-jhipster-micronaut)
+- GitHub ⭐️: 91
+- Stream lead: [Frederik Hahne](https://github.com/atomfrede)
 
 ## Svelte
 
-The Svelte blueprint replaces the client-side code with the SvelteKit framework. Source code and documentation could be found in the [generator-jhipster-svelte](https://github.com/jhipster/generator-jhipster-svelte) repository. {⭐️: 44}
+The Svelte blueprint replaces the client-side code with the SvelteKit framework. 
 
-Stream lead: [Vishal Mahajan](https://github.com/vishal423)
+- Code and docs: [jhipster/generator-jhipster-svelte](https://github.com/jhipster/generator-jhipster-svelte)
+- GitHub ⭐️: 44
+- Stream lead: [Vishal Mahajan](https://github.com/vishal423)
 
 ## JHipster Native
 
-The JHipster Native blueprint integrates Spring Native, making it possible to create a native binary with GraalVM. Source code and documentation could be found in the [generator-jhipster-native](https://github.com/jhipster/generator-jhipster-native) repository. {⭐️: 28}
+The JHipster Native blueprint integrates Spring Native, making it possible to create a native binary with GraalVM. 
 
-Stream leads: [Marcelo Shima](https://github.com/mshima) and [Matt Raible](https://github.com/mraible)
+- Code and docs: [jhipster/generator-jhipster-native](https://github.com/jhipster/generator-jhipster-native)
+- GitHub ⭐️: 28
+- Stream leads: [Marcelo Shima](https://github.com/mshima) and [Matt Raible](https://github.com/mraible)
 
 # jOOQ
 
-The jOOQ blueprint integrates jOOQ as the persistence layer. Source code and documentation can be found in the [generator-jhipster-jooq](https://github.com/jhipster/generator-jhipster-jooq) repository. {⭐️: 6}
+The jOOQ blueprint integrates jOOQ as the persistence layer. 
 
-Stream lead: [Marcelo Shima](https://github.com/mshima)
+- Code and Docs: [jhipster/generator-jhipster-jooq](https://github.com/jhipster/generator-jhipster-jooq)
+- GitHub ⭐️: 6
+- Stream lead: [Marcelo Shima](https://github.com/mshima)

--- a/modules/official-blueprints.md
+++ b/modules/official-blueprints.md
@@ -33,7 +33,7 @@ The .NET Core blueprint is the first attempt to leave the Java environment and j
 
 - Code and docs: [jhipster/jhipster-dotnetcore](https://github.com/jhipster/jhipster-dotnetcore)
 - GitHub ⭐️: 249
-- Stream lead: [Daniel Petisme](https://github.com/danielpetisme)
+- Stream lead: [Nicolas Raymond](https://github.com/nicolas63)
 
 ## React Native
 

--- a/modules/official-blueprints.md
+++ b/modules/official-blueprints.md
@@ -23,38 +23,44 @@ The blueprints below are ordered by the number of stars they have on GitHub.
 
 The Kotlin blueprint replaces most of Java back-end code with Kotlin. Source code and documentation could be found in the [jhipster-kotlin](https://github.com/jhipster/jhipster-kotlin) repository. {⭐️: 411}
 
-Stream lead is: [Sendil Kumar](https://github.com/sendilkumarn).
+Stream lead: [Sendil Kumar](https://github.com/sendilkumarn)
 
 ## .NET Core
 
 The .NET Core blueprint is the first attempt to leave the Java environment and join the .NET world. Source code and documentation could be found in the [jhipster-dotnetcore](https://github.com/jhipster/jhipster-dotnetcore) repository. {⭐️: 249}
 
-Stream lead is: [Daniel Petisme](https://github.com/danielpetisme).
+Stream lead: [Daniel Petisme](https://github.com/danielpetisme)
 
 ## React Native
 
 The React Native blueprint creates a client application with React Native. Source code and documentation could be found in the [generator-jhipster-react-native](https://github.com/jhipster/generator-jhipster-react-native) repository. {⭐️: 235}
 
-Stream lead is: [Jon Ruddell](https://github.com/ruddell).
+Stream lead: [Jon Ruddell](https://github.com/ruddell)
 
 ## Node.js
 
 The Node.js blueprint replaces the server java side with the NestJS Node framework. Source code and documentation could be found in the [generator-jhipster-nodejs](https://github.com/jhipster/generator-jhipster-nodejs) repository. {⭐️: 223}
 
-Stream lead is: [Angelo Manganiello](https://github.com/amanganiello90).
+Stream lead: [Angelo Manganiello](https://github.com/amanganiello90)
 
 ## Ionic
 
 The Ionic blueprint creates a client application with Ionic. Source code and documentation could be found in the [generator-jhipster-ionic](https://github.com/jhipster/generator-jhipster-ionic) repository. {⭐️: 170}
 
-Stream lead is: [Matt Raible](https://github.com/mraible).
+Stream lead: [Matt Raible](https://github.com/mraible)
 
 ## Quarkus
 
 The Quarkus blueprint is supported, in part by the JHipster sponsor [Entando](https://www.entando.com/), and driven by the JHipster community for a [supersonic, subatomic Java back-end](https://quarkus.io/).
 Source code and documentation can be found in the [generator-jhipster-quarkus](https://github.com/jhipster/generator-jhipster-quarkus) repository. {⭐️: 111}
 
-Stream lead is [Anthony Viard](https://github.com/avdev4j).
+Stream lead: [Anthony Viard](https://github.com/avdev4j)
+
+# Entity Audit
+
+The Entity Audit blueprint integrates Javers for entity auditing. Source code and documentation can be found in the [generator-jhipster-entity-audit](https://github.com/hipster-labs/generator-jhipster-entity-audit) repository. {⭐️: 107}
+
+Stream lead: [Marcelo Shima](https://github.com/mshima)
 
 ## Micronaut
 
@@ -62,16 +68,22 @@ The Micronaut blueprint is supported and driven by people of the [Micronaut team
 It replaces all server side code with a [Micronaut](https://micronaut.io/) application.
 Source code and documentation can be found in the [generator-jhipster-micronaut](https://github.com/jhipster/generator-jhipster-micronaut) repository. {⭐️: 91}
 
-Stream lead is [Frederik Hahne](https://github.com/atomfrede).
+Stream lead: [Frederik Hahne](https://github.com/atomfrede)
 
 ## Svelte
 
 The Svelte blueprint replaces the client-side code with the SvelteKit framework. Source code and documentation could be found in the [generator-jhipster-svelte](https://github.com/jhipster/generator-jhipster-svelte) repository. {⭐️: 44}
 
-Stream lead is: [Vishal Mahajan](https://github.com/vishal423).
+Stream lead: [Vishal Mahajan](https://github.com/vishal423)
 
 ## JHipster Native
 
 The JHipster Native blueprint integrates Spring Native, making it possible to create a native binary with GraalVM. Source code and documentation could be found in the [generator-jhipster-native](https://github.com/jhipster/generator-jhipster-native) repository. {⭐️: 28}
 
-Stream lead is: [Marcelo Shima](https://github.com/mshima).
+Stream leads: [Marcelo Shima](https://github.com/mshima) and [Matt Raible](https://github.com/mraible)
+
+# jOOQ
+
+The j00Q blueprint integrates j00Q as the persistence layer. Source code and documentation can be found in the [generator-jhipster-jooq](https://github.com/jhipster/generator-jhipster-jooq) repository. {⭐️: 6}
+
+Stream lead: [Marcelo Shima](https://github.com/mshima)

--- a/modules/official-blueprints.md
+++ b/modules/official-blueprints.md
@@ -65,7 +65,7 @@ The Quarkus blueprint is supported, in part by the JHipster sponsor [Entando](ht
 
 - Code and docs: [jhipster/generator-jhipster-quarkus](https://github.com/jhipster/generator-jhipster-quarkus)
 - GitHub ⭐️: 111
-- Stream lead: [Anthony Viard](https://github.com/avdev4j)
+- Stream lead: [Matt Raible](https://github.com/mraible)
 
 # Entity Audit
 

--- a/modules/official-blueprints.md
+++ b/modules/official-blueprints.md
@@ -84,6 +84,6 @@ Stream leads: [Marcelo Shima](https://github.com/mshima) and [Matt Raible](https
 
 # jOOQ
 
-The j00Q blueprint integrates j00Q as the persistence layer. Source code and documentation can be found in the [generator-jhipster-jooq](https://github.com/jhipster/generator-jhipster-jooq) repository. {⭐️: 6}
+The jOOQ blueprint integrates jOOQ as the persistence layer. Source code and documentation can be found in the [generator-jhipster-jooq](https://github.com/jhipster/generator-jhipster-jooq) repository. {⭐️: 6}
 
 Stream lead: [Marcelo Shima](https://github.com/mshima)

--- a/modules/official-blueprints.md
+++ b/modules/official-blueprints.md
@@ -19,8 +19,6 @@ The JHipster team maintains several official blueprints. These blueprints have t
 
 The blueprints below are ordered by the number of stars they have on GitHub. 
 
-{:toc}
-
 ## Kotlin
 
 The Kotlin blueprint replaces most of Java back-end code with Kotlin. Source code and documentation could be found in the [jhipster-kotlin](https://github.com/jhipster/jhipster-kotlin) repository. {⭐️: 411}


### PR DESCRIPTION
I'm tagging the stream leads for each blueprint in this update to make sure y'all still want to lead:

- Kotlin: @sendilkumarn ✅
- .NET Core: @nicolas63 ✅
- React Native: @ruddell
- Node.js: @amanganiello90 ✅
- Ionic: @mraible ✅
- Quarkus: @mraible ✅
- Micronaut: @atomfrede ✅
- Svelte: @vishal423 ✅
- JHipster Native: @mshima and @mraible ✅
- jOOQ: @mshima ✅
- Entity Audit: @mshima ✅