### PR TITLE
Elasticsearch documentation cleanup

### DIFF
--- a/pages/using_elasticsearch.md
+++ b/pages/using_elasticsearch.md
@@ -28,7 +28,7 @@ When the Elasticsearch option is selected:
 
 ### Using in Development
 
-In development, JHipster runs with an embedded Elasticsearch instance. You can also use an external Elasticsearch instance if you set a `SPRING_DATA_JEST_URI` environment variable (or add a `spring.data.jest.uri` property to your `application-dev.yml`). 
+In development, JHipster expects an Elasticsearch instance (it does no longer support emdedded ES) running on `localhost:9200`. You can also set a `SPRING_ELASTICSEARCH_URIS` environment variable (or add a `spring.elasticsearch.uris` property to your `application-dev.yml`). 
 
 The easiest way to run an external Elasticsearch instance is to use the provided Docker Compose configuration:
 
@@ -36,7 +36,7 @@ The easiest way to run an external Elasticsearch instance is to use the provided
     
 Then set an environment variable to point to it:
 
-    export SPRING_DATA_JEST_URI=http://localhost:9200
+    export SPRING_ELASTICSEARCH_URIS=http://localhost:9200
 
 ### Using in Production
 


### PR DESCRIPTION
The support of embedded ES was dropped in JHipster. The documentation should reflect this.