### PR TITLE
docs: correct the link to blueprint-basics off page

### DIFF
--- a/modules/creating_a_module.md
+++ b/modules/creating_a_module.md
@@ -14,7 +14,7 @@ sitemap:
 
 As of JHipster v7.9.0, module support was merged into blueprint support. So the same rules apply.
 
-Before creating a Blueprint, make sure you have read [Blueprint Basics](/module/blueprint-basics)
+Before creating a Blueprint, make sure you have read [Blueprint Basics](/modules/extending-and-customizing/#-blueprint-basics)
 
 ## Example
 

--- a/modules/extending_and_customizing.md
+++ b/modules/extending_and_customizing.md
@@ -55,10 +55,10 @@ JHipster has many official blueprints, some examples:
 - Mobile
   - [JHipster Ionic](https://github.com/jhipster/generator-jhipster-ionic) blueprint generates an Ionic application.
 
-## Side-by-side blueprint
+## Side-by-Side blueprint
 
-Each generator can be a side-by-side (SBS) blueprint. An sbs blueprint doesn't change the original generator's behavior but can customize the behavior and the result.
-Side-by-side blueprint makes easier to support multiple JHipster versions and port to a new JHipster version.
+Each generator can be a side-by-side (SBS) blueprint. A SBS blueprint doesn't change the original generator's behavior but can customize the behavior and the result.
+A SBS blueprint makes easier to support multiple JHipster versions and port to a new JHipster version.
 
 To make the generator side-by-side, add this to the constructor:
 
@@ -67,19 +67,18 @@ this.sbsBlueprint = true;
 ```
 
 Example: [server generator at Native Blueprint](https://github.com/jhipster/generator-jhipster-native/blob/bb9c042f6bc70a26ba8037e951c93dc1d1820983/generators/server/generator.mjs#L17).
-At this example the generator [customizes package.json](https://github.com/jhipster/generator-jhipster-native/blob/bb9c042f6bc70a26ba8037e951c93dc1d1820983/generators/server/generator.mjs#L26-L35), [removes files](https://github.com/jhipster/generator-jhipster-native/blob/bb9c042f6bc70a26ba8037e951c93dc1d1820983/generators/server/generator.mjs#L37-L40), [customizes pom.xml](https://github.com/jhipster/generator-jhipster-native/blob/bb9c042f6bc70a26ba8037e951c93dc1d1820983/generators/server/generator.mjs#L42-L186), [customizes java files](https://github.com/jhipster/generator-jhipster-native/blob/bb9c042f6bc70a26ba8037e951c93dc1d1820983/generators/server/generator.mjs#L211-L307), [customizes cypress](https://github.com/jhipster/generator-jhipster-native/blob/bb9c042f6bc70a26ba8037e951c93dc1d1820983/generators/server/generator.mjs#L321-L329) and so one.
+In the example, the generator [customizes package.json](https://github.com/jhipster/generator-jhipster-native/blob/bb9c042f6bc70a26ba8037e951c93dc1d1820983/generators/server/generator.mjs#L26-L35), [removes files](https://github.com/jhipster/generator-jhipster-native/blob/bb9c042f6bc70a26ba8037e951c93dc1d1820983/generators/server/generator.mjs#L37-L40), [customizes the pom.xml](https://github.com/jhipster/generator-jhipster-native/blob/bb9c042f6bc70a26ba8037e951c93dc1d1820983/generators/server/generator.mjs#L42-L186), [customizes Java files](https://github.com/jhipster/generator-jhipster-native/blob/bb9c042f6bc70a26ba8037e951c93dc1d1820983/generators/server/generator.mjs#L211-L307), [customizes Cypress](https://github.com/jhipster/generator-jhipster-native/blob/bb9c042f6bc70a26ba8037e951c93dc1d1820983/generators/server/generator.mjs#L321-L329), and so on.
 
 A side-by-side blueprint can be used to create hooks and help migrate an existing module. This is covered in [Creating a module](/modules/creating-a-module).
 
 ## Custom CLI
 
-Standalone blueprints can be executed using `yo`, but `yo` is aggressive in generators discovery (can be slow) and lacks some improvements. The JHipster CLI provides help and JHipster integration.
+Standalone blueprints can be executed using `yo`, but `yo` is aggressive in generators discovery—which can be slow—and lacks some improvements. The JHipster CLI provides help and JHipster integration.
 Therefore, we recommend using the `jhipster` CLI or creating a custom CLI based on `generator-jhipster`.
 
-The `jhipster` command executes the `generator-jhipster` version you have installed globally.
-A custom CLI will execute the dependent `generator-jhipster` and will make sure to use the supported `generator-jhipster`'s version.
+The `jhipster` command executes the `generator-jhipster` version you have installed globally. A custom CLI will execute the dependent `generator-jhipster` and will make sure to use the supported `generator-jhipster`'s version.
 
-Custom CLI allows you to execute a custom generator and is covered in [Creating a module](/modules/creating-a-module).
+A custom CLI allows you to execute a custom generator and is covered in [Creating a module](/modules/creating-a-module).
 
 ## Local Blueprint
 


### PR DESCRIPTION
The link to Blueprint Basics is 404. Correct by linking to the headline fragment of Creating a Module.