### PR TITLE
Add mention of tool to transform SQL to JDL

### DIFF
--- a/pages/jdl/intro.md
+++ b/pages/jdl/intro.md
@@ -51,3 +51,8 @@ documentation:
 
 You can also check the official [JDL sample repository](https://github.com/jhipster/jdl-samples) and propose examples 
 if you want!
+
+---
+
+In case you already have existing databases and would like to create the JDL representation then you can use
+this project [SQL to JDL](https://github.com/Blackdread/sql-to-jdl) which will help you get started quickly.


### PR DESCRIPTION
Fixes https://github.com/jhipster/generator-jhipster/issues/20759

Add mention of tool to transform SQL to JDL

@pascalgrimaud Is `main` or `master` branch that should be used? It seems that `main` should actually be the branch to use (Previous PR https://github.com/jhipster/jhipster.github.io/pull/1271 was merged in master but main and master now differs for quite some time)