### PR TITLE
Remove Ippon from compagnies supporting JHipster

### DIFF
--- a/index.html
+++ b/index.html
@@ -267,7 +267,7 @@ sitemap:
                         <div>
                             <p>This support consists of:</p>
                             <ul>
-                                <li>Time for development by core contributors (Ippon Technologies, Okta, Entando)</li>
+                                <li>Time for development by core contributors (Okta, Entando)</li>
                                 <li>Development of the Micronaut Blueprint (Object Computing)</li>
                                 <li>Participation in the Quarkus Blueprint development (Entando)</li>
                             </ul>
@@ -277,15 +277,6 @@ sitemap:
                 </div>
                 <div class="col-md-12 text-center">
                     <div class="row">
-                        <div class="col-sm-12 col-md-4">
-                            <div class="thumbnail no-margin-bottom">
-                                <div class="logo-container">
-                                    <a href="https://en.ippon.tech/" target="_blank" rel="noopener">
-                                        <img src="{{ site.url }}/images/support/ippon.png">
-                                    </a>
-                                </div>
-                            </div>
-                        </div>
                         <div class="col-sm-12 col-md-4">
                             <div class="thumbnail no-margin-bottom">
                                 <div class="logo-container">


### PR DESCRIPTION
No contribution from the company since end of 2022, in generator-jhipster or in jhipster-lite project
Anyway, 1 day / month, is clearly not enough to work on an open source project :)

cc @hdurix @juliensadaoui, following my private mail to you