### PR TITLE
Remove Entando from companies supporting JHipster

### DIFF
--- a/index.html
+++ b/index.html
@@ -267,9 +267,8 @@ sitemap:
                         <div>
                             <p>This support consists of:</p>
                             <ul>
-                                <li>Time for development by core contributors (Okta, Entando)</li>
+                                <li>Time for development by core contributors (Okta)</li>
                                 <li>Development of the Micronaut Blueprint (Object Computing)</li>
-                                <li>Participation in the Quarkus Blueprint development (Entando)</li>
                             </ul>
                             <p>If you wish your company to be added here, don't hesitate to reach out to us and explain why.</p>
                         </div>
@@ -291,15 +290,6 @@ sitemap:
                                 <div class="logo-container">
                                     <a href="https://objectcomputing.com/" target="_blank" rel="noopener">
                                         <img src="{{ site.url }}/images/support/oci.png">
-                                    </a>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="col-sm-12 col-md-4">
-                            <div class="thumbnail no-margin-bottom">
-                                <div class="logo-container">
-                                    <a href="https://entando.com/" target="_blank" rel="noopener">
-                                        <img src="{{ site.url }}/images/support/entando.png">
                                     </a>
                                 </div>
                             </div>


### PR DESCRIPTION
Entando still appears as Gold Sponsor, but no more in companies supporting JHipster

cc @avdev4j as discussed