### PR TITLE
Remove Object Computing from companies supporting JHipster

### DIFF
--- a/index.html
+++ b/index.html
@@ -268,7 +268,6 @@ sitemap:
                             <p>This support consists of:</p>
                             <ul>
                                 <li>Time for development by core contributors (Okta)</li>
-                                <li>Development of the Micronaut Blueprint (Object Computing)</li>
                             </ul>
                             <p>If you wish your company to be added here, don't hesitate to reach out to us and explain why.</p>
                         </div>
@@ -281,15 +280,6 @@ sitemap:
                                 <div class="logo-container">
                                     <a href="https://developer.okta.com/?utm_campaign=display_website_all_multiple_dev_dev_jhipster-q2_&utm_source=jhipster&utm_medium=cpc" target="_blank" rel="noopener">
                                         <img src="{{ site.url }}/images/support/okta.png">
-                                    </a>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="col-sm-12 col-md-4">
-                            <div class="thumbnail no-margin-bottom">
-                                <div class="logo-container">
-                                    <a href="https://objectcomputing.com/" target="_blank" rel="noopener">
-                                        <img src="{{ site.url }}/images/support/oci.png">
                                     </a>
                                 </div>
                             </div>


### PR DESCRIPTION
No more activity from Micronaut Team in the [blueprint](https://github.com/jhipster/generator-jhipster-micronaut) since may 2021

![image](https://user-images.githubusercontent.com/9156882/231156604-7c79ba07-07db-4811-a954-63fc7dcf6790.png)
