### PR TITLE
Add language selection feature

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -124,10 +124,10 @@
                                 </li>
                                 -->
                                 <li>
-                                    <a href="{{ site.url }}/cn{{page.url}}">中文</a>
+                                    <a href="/cn{{page.url}}">中文</a>
                                 </li>
                                 <li>
-                                    <a href="{{ site.url }}/ja{{page.url}}">日本語</a>
+                                    <a href="/jp{{page.url}}">日本語</a>
                                 </li>
                             </ul>                             
                         <li>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -112,9 +112,24 @@
                                 <input type="text" name="search" class="doc-search-algolia" placeholder="Search..." />
                             </form>
                         </li>
-                        <li>
-                            <a href="{{ site.url }}/cn{{page.url}}"><i class="fa fa-fw fa-globe"></i> 中文</a>
-                        </li>
+                        <li class="nav-item dropdown">
+                            <a class="dropdown-toggle" id="languages-toggle-dropdown" data-toggle="dropdown" role="button" aria-haspopup="true">                                
+                                <i class="fa fa-fw fa-globe"></i> English
+                                <span class="caret"></span> 
+                            </a>
+                            <ul class="dropdown-menu" aria-labelledby="languages-toggle-dropdown">
+                                <!--
+                                <li>
+                                    <a href="{{ page.url }}">English</a>
+                                </li>
+                                -->
+                                <li>
+                                    <a href="{{ site.url }}/cn{{page.url}}">中文</a>
+                                </li>
+                                <li>
+                                    <a href="{{ site.url }}/ja{{page.url}}">日本語</a>
+                                </li>
+                            </ul>                             
                         <li>
                             <button type="button" class="navbar-right-expand-toggle visible-xs pull-right light">
                                 <i class="fa fa-times icon"></i>

--- a/css/scss/themes/flat-blue.scss
+++ b/css/scss/themes/flat-blue.scss
@@ -219,12 +219,31 @@ $theme-danger-color: $color-red;
         }
       }
       .dropdown-menu {
-        background-color: $color-light-grey;
+        right: auto;
+        left: 0;
+        background-color: $color-dark-blue;
+        font-size: 16px;
+        margin-left: 25px;
+        min-width: auto;
         border-color: $color-dark-blue;
         .title {
           background-color: $color-white;
           .badge {
             background-color: $color-dark-blue;
+          }
+        }
+        & > li {
+          & > a {
+            font-family: roboto condensed,sans-serif;
+            font-weight: 700;
+            height: 60px;
+            line-height: 60px;
+            padding: 0 20px;
+            color: $color-white;
+            background-color: $color-dark-blue;
+          }
+          &:hover > a { 
+            color: $color-dark-blue-1; 
           }
         }
       }

--- a/css/themes/flat-blue.css
+++ b/css/themes/flat-blue.css
@@ -119,7 +119,12 @@
   background-color: #FA2A00;
 }
 .flat-blue .navbar.navbar-inverse .navbar-nav .dropdown-menu {
-  background-color: #F9F9F9;
+  right: auto;
+  left: 0;
+  background-color: #353d47;
+  font-size: 16px;
+  margin-left: 25px;
+  min-width: auto;
   border-color: #353d47;
 }
 .flat-blue .navbar.navbar-inverse .navbar-nav .dropdown-menu .title {
@@ -127,6 +132,18 @@
 }
 .flat-blue .navbar.navbar-inverse .navbar-nav .dropdown-menu .title .badge {
   background-color: #353d47;
+}
+.flat-blue .navbar.navbar-inverse .navbar-nav .dropdown-menu > li > a {
+  font-family: roboto condensed, sans-serif;
+  font-weight: 700;
+  height: 60px;
+  line-height: 60px;
+  padding: 0 20px;
+  color: #FFF;
+  background-color: #353d47;
+}
+.flat-blue .navbar.navbar-inverse .navbar-nav .dropdown-menu > li:hover > a {
+  color: #3E8ACC;
 }
 .flat-blue .navbar.navbar-inverse .navbar-nav .dropdown-menu.danger {
   border-color: #FA2A00;


### PR DESCRIPTION
Related to https://github.com/jhipster/generator-jhipster/issues/21897

This is a proposal for a feature allowing the selection of multiple languages on the site. 
A sample can be found on the newly created [Japanese site](https://www.jhipster.tech/jp/)

The envisioned layout for the English site is as follows:

<img width="319" alt="language-selector" src="https://user-images.githubusercontent.com/3602892/235301682-9d151b83-5240-4cb4-94a0-6b0b9896596a.png">

The reason I adjusted the CSS (by modifying the SCSS and executing `npm run sass`) is because there were no suitable styles for the dropdown on the navi-bar. A bit of hardcoding was necessary to adjust the layout.

If this proposal is accepted, I plan to submit a similar PR to [the Chinese site](https://www.jhipster.tech/cn/) (This would only require minor adjustments to the commented-out code).

Thank you in advance for your consideration.
