### PR TITLE
Clarify i18n files for CDN caching

### DIFF
--- a/pages/separating-front-end-and-api.md
+++ b/pages/separating-front-end-and-api.md
@@ -47,6 +47,7 @@ Once the front-end and back-end have been separated, the issue will be how to ha
 - All API calls will use a `/api` prefix. If you are using Angular, there is also a specific `SERVER_API_URL` constant, defined in the `webpack.common.js` configuration, that can enrich this prefix. For example, you can use `"http://api.jhipster.tech:8081/"` as a back-end API server (If you do this, please read our documentation on CORS below).
 - `/index.html` should not be cached by the browser or server.
 - Calls to `/` that serve static assets (from the front-end) `/app` (which contains the client-side application) and `/content` (which contains the static content, like images and CSS) should be cached in production, as those assets are hashed.
+- Calls to `/i18n` can be cached but files itsefs not are hashed, url query string are used
 - Calls to a non-existent route should forward the request to `index.html`. This is normally handled in the backend through `ClientForwardController`. When deploying the client separately, this needs to be configured.  See the [Angular](https://angular.io/guide/deployment#server-configuration) or [React](https://facebook.github.io/create-react-app/docs/deployment) documentation for several examples.
 
 # Using BrowserSync


### PR DESCRIPTION
i18n content are served with query strings like:

`/i18n/es.json?_=e81a38b6ae20bcf2a04e59c0495c0c5`

Should be configured properly on CDN