### PR TITLE
Updated link to JHipster Mini-Book v7 on InfoQ

### DIFF
--- a/index.html
+++ b/index.html
@@ -144,7 +144,7 @@ sitemap:
                     <div>
                         <h3>Books</h3>
                         <ul>
-                            <li><a href="https://www.infoq.com/minibooks/jhipster-mini-book-5" target="_blank" rel="noopener">The JHipster Mini-Book 5.0</a> by Matt Raible. This edition includes new sections on progressive web apps (PWA), code quality, and securing user data.</li>
+                            <li><a href="https://www.infoq.com/minibooks/jhipster-mini-book-7" target="_blank" rel="noopener">The JHipster Mini-Book 7.0</a> by Matt Raible. This edition includes an updated microservices section that features WebFlux and micro frontends with React.</li>
                             <li><b>Full Stack Development with JHipster - Second edition</b> by Deepu K Sasidharan and Sendil Kumar. Get it on <a href="https://www.packtpub.com/web-development/full-stack-development-with-jhipster-second-edition" target="_blank" rel="noopener">Packt</a> and <a href="https://smile.amazon.com/Full-Stack-Development-JHipster-microservices/dp/1838824987" target="_blank" rel="noopener">Amazon</a>.</li>
                         </ul>
                         <h3>Community Tutorials/Trainings</h3>


### PR DESCRIPTION
Updated index.html with a link to the latest JHipster Mini-Book v7 on InfoQ.