### PR TITLE
updated hyperlinks pointing to archived jhipster/jhipster-core repository

### DIFF
--- a/pages/jdl/intro.md
+++ b/pages/jdl/intro.md
@@ -6,7 +6,7 @@ redirect_from:
   - /jdl/
 sitemap:
     priority: 0.5
-    lastmod: 2019-10-27T12:00:00-00:00
+    lastmod: 2023-07-09T23:00:00-00:00
 ---
 
 # <i class="fa fa-star"></i> JHipster Domain Language (JDL)
@@ -27,10 +27,10 @@ recommended approach.
 The idea is that it is much easier to [manage relationships]({{ site.url }}/managing-relationships/) using a visual tool
 than with the classical Yeoman questions and answers.
 
-The JDL project is [available on GitHub](https://github.com/jhipster/jhipster-core/), it is an Open Source project like
+The JDL project is [available on GitHub](https://github.com/jhipster/generator-jhipster/), it is an Open Source project like
 JHipster (Apache 2.0 License). It can also be used as a node library to do JDL parsing.
 
-_If you like the [JHipster Domain Language](https://github.com/jhipster/jhipster-core/),
+_If you like the [JHipster Domain Language](https://github.com/jhipster/generator-jhipster/),
 the [JDL Studio](https://github.com/jhipster/jdl-studio/) or the
 [JHipster IDE](https://github.com/jhipster/jhipster-ide/) don't forget to give them a star on
 [GitHub](https://github.com/jhipster/) - thanks_!

--- a/pages/jdl/troubleshooting.md
+++ b/pages/jdl/troubleshooting.md
@@ -4,7 +4,7 @@ title: JHipster Domain Language - Troubleshooting
 permalink: /jdl/troubleshooting
 sitemap:
     priority: 0.5
-    lastmod: 2019-10-27T12:00:00-00:00
+    lastmod: 2023-07-09T23:00:00-00:00
 ---
 
 # <i class="fa fa-star"></i> JHipster Domain Language (JDL)
@@ -19,7 +19,7 @@ You can do these things with it:
   - And declare some JHipster specific options.
 
 If you wish to view the JDL's grammar, there is an HTML file available
-[here](https://github.com/jhipster/jhipster-core/blob/master/lib/dsl/gen/grammar.html).
+[here](https://github.com/jhipster/generator-jhipster/blob/master/jdl/parsing/generated/grammar.html).
 
 ---
 
@@ -34,13 +34,14 @@ See [JHipster Core issue #308](https://github.com/jhipster/jhipster-core/issues/
 
 <h2 id="issues">Issues and bugs</h2>
 
-The JDL is [available on GitHub](https://github.com/jhipster/jhipster-core), and follows the same
+The JDL is [available on GitHub](https://github.com/jhipster/generator-jhipster/tree/main/jdl), and follows the same
 [contributing guidelines as JHipster]( https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md).
 
-Please use our project for submitting issues and Pull Requests concerning the library itself.
+Please use the ["JDL"](https://github.com/jhipster/generator-jhipster/labels/theme%3A%20JDL) label for submitting 
+issues and Pull Requests concerning the library itself.
 
-- [JDL issue tracker](https://github.com/jhipster/jhipster-core/issues)
-- [JDL Pull Requests](https://github.com/jhipster/jhipster-core/pulls)
+- [JDL issue tracker](https://github.com/jhipster/generator-jhipster/issues?q=is%3Aopen+is%3Aissue+label%3A%22theme%3A+JDL%22)
+- [JDL Pull Requests](https://github.com/jhipster/generator-jhipster/pulls?q=is%3Aopen+is%3Apr+label%3A%22theme%3A+JDL%22)
 
 When submitting anything, you must be as precise as possible:  
   - **One posted issue must only have one problem** (or one demand/question);  


### PR DESCRIPTION
* Updated hyperlinks pointing to archived [jhipster/jhipster-core repository](https://github.com/jhipster/jhipster-core)
* Slightly modified "Issues and bugs" section in [troubleshooting.md](https://github.com/jhipster/jhipster.github.io/compare/main...Alchemik:jhipster.github.io:update-hyperlinks-to-deprecated-jhipster-core-repo?expand=1#diff-b037ecef5872f1375b19296b36c0725de20188198891624d794d65fe51980eb5)