### PR TITLE
Lighthouse: alts are missing on the home page

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -144,7 +144,7 @@
                     <div class="side-menu-container">
                         <div class="navbar-header">
                             <a class="navbar-brand" href="/">
-                                <div class="icon"><img src="{{ site.url }}/images/logo/logo-jhipster.svg" height="19px"></div>
+                                <div class="icon"><img src="{{ site.url }}/images/logo/logo-jhipster.svg" alt="Logo JHipster" height="19px"></div>
                                 <div class="title brand">JHipster </div>
                             </a>
                             <button type="button" class="navbar-expand-toggle pull-right visible-xs">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -144,7 +144,7 @@
                     <div class="side-menu-container">
                         <div class="navbar-header">
                             <a class="navbar-brand" href="/">
-                                <div class="icon"><img src="{{ site.url }}/images/logo/logo-jhipster.svg" alt="Logo JHipster" height="19px"></div>
+                                <div class="icon"><img src="{{ site.url }}/images/logo/logo-jhipster.svg" alt="JHipster" height="19px"></div>
                                 <div class="title brand">JHipster </div>
                             </a>
                             <button type="button" class="navbar-expand-toggle pull-right visible-xs">

--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@ sitemap:
         <div class="container">
             <div class="row">
                 <div class="col-lg-12">
-                    <div class="logo-big"><img class="img-responsive" id="hipster" src="images/logo/jhipster_family_member_1.svg" alt=""></div>
+                    <div class="logo-big"><img class="img-responsive" id="hipster" src="images/logo/jhipster_family_member_1.svg" alt="JHipster Family Member"></div>
                     <div class="intro-text">
                         <span class="brand">Greetings, Java Hipster!</span>
                         <hr class="star-light">
@@ -176,7 +176,7 @@ sitemap:
                     </p>
                     <p>
                         <a href="https://opencollective.com/generator-jhipster/donate" target="_blank">
-                            <img src="https://opencollective.com/generator-jhipster/donate/button@2x.png?color=blue" width=300 />
+                            <img src="https://opencollective.com/generator-jhipster/donate/button@2x.png?color=blue" alt="Donate" width=300 />
                         </a>
                     </p>
                 </div>
@@ -239,7 +239,7 @@ sitemap:
                             <div class="thumbnail no-margin-bottom">
                                 <div class="logo-container">
                                     <a href="https://auth0.com/blog/micro-frontends-for-java-microservices/" target="_blank" rel="noopener">
-                                        <img src="{{ site.url }}/images/support/okta.png">
+                                        <img src="{{ site.url }}/images/support/okta.png" alt="Okta">
                                     </a>
                                 </div>
                             </div>
@@ -293,15 +293,15 @@ sitemap:
             <div class="row">
                 <span class="title text-center">
                     <div class="head-icons">
-                        <a href="http://projects.spring.io/spring-boot/" target="_blank" rel="noopener"><img src="images/logo/svg/spring-boot.svg" class="project-icon img-responsive"></a>
+                        <a href="http://projects.spring.io/spring-boot/" target="_blank" rel="noopener"><img src="images/logo/svg/spring-boot.svg" alt="Spring Boot" class="project-icon img-responsive"></a>
                         <i class="fa fa-4x">+</i>
-                        <a href="https://angular.io/" target="_blank" rel="noopener"><img src="images/logo/svg/angular.svg" class="project-icon img-responsive"></a><br class="visible-xs">
+                        <a href="https://angular.io/" target="_blank" rel="noopener"><img src="images/logo/svg/angular.svg" alt="Angular" class="project-icon img-responsive"></a><br class="visible-xs">
                         <i class="fa fa-4x">/</i>
-                        <a href="https://reactjs.org/" target="_blank" rel="noopener"><img src="images/logo/svg/react.svg" class="project-icon img-responsive"></a><br class="visible-xs">
+                        <a href="https://reactjs.org/" target="_blank" rel="noopener"><img src="images/logo/svg/react.svg" alt="React" class="project-icon img-responsive"></a><br class="visible-xs">
                         <i class="fa fa-4x">/</i>
-                        <a href="https://vuejs.org/" target="_blank" rel="noopener"><img src="images/logo/svg/vue.svg" class="project-icon img-responsive"></a><br class="visible-xs">
+                        <a href="https://vuejs.org/" target="_blank" rel="noopener"><img src="images/logo/svg/vue.svg" alt="Vue" class="project-icon img-responsive"></a><br class="visible-xs">
                         <i class="fa fa-4x">=</i>
-                        <a href="/"><img id="hipster-head" src="images/logo/jhipster_family_member_0_head.svg" class="project-icon img-responsive"></a>
+                        <a href="/"><img id="hipster-head" src="images/logo/jhipster_family_member_0_head.svg" alt="JHipster Family Member" class="project-icon img-responsive"></a>
                     </div>
                     <p class="lead font-weight-normal">
                         JHipster is a development platform to quickly generate, develop, and deploy modern web applications and microservice architectures. We support many frontend technologies, including Angular, React, and Vue. We even have mobile app support for Ionic and React Native! On the backend, we support Spring Boot (with Java or Kotlin), Micronaut, Quarkus, Node.js, and .NET. For deployment, we embrace cloud native principles with Docker and Kubernetes. Deployment support exists for AWS, Azure, Cloud Foundry, Google Cloud Platform, Heroku, and OpenShift.
@@ -362,67 +362,67 @@ sitemap:
         <div class="row stack-container no-margin">
             <ul class="text-center stacks">
                 <li class="clip img-circle">
-                    <img src="images/logo/svg/html-5.svg" />
+                    <img src="images/logo/svg/html-5.svg" alt="" />
                     <span class="title_sub_tech">HTML5</span>
                 </li>
                 <li class="clip img-circle">
-                    <img src="images/logo/svg/css-3.svg" />
+                    <img src="images/logo/svg/css-3.svg" alt="" />
                     <span class="title_sub_tech">CSS3</span>
                 </li>
                 <li class="clip img-circle">
-                    <img src="images/logo/svg/bootstrap.svg" />
+                    <img src="images/logo/svg/bootstrap.svg" alt="" />
                     <span class="title_sub_tech">Bootstrap</span>
                 </li>
                 <li class="clip img-circle new">
-                    <img src="images/logo/svg/typescript.svg" />
+                    <img src="images/logo/svg/typescript.svg" alt="" />
                     <span class="title_sub_tech">TypeScript</span>
                 </li>
                 <li class="clip img-circle new">
-                    <img src="images/logo/svg/angular.svg" />
+                    <img src="images/logo/svg/angular.svg" alt="" />
                     <span class="title_sub_tech">Angular</span>
                 </li>
                 <li class="clip img-circle new">
-                    <img src="images/logo/svg/react.svg" />
+                    <img src="images/logo/svg/react.svg" alt="" />
                     <span class="title_sub_tech">React</span>
                 </li>
                 <li class="clip img-circle new">
-                    <img src="images/logo/svg/vue.svg" />
+                    <img src="images/logo/svg/vue.svg" alt="" />
                     <span class="title_sub_tech">Vue</span>
                 </li>
                 <li class="clip img-circle new">
-                    <img src="images/logo/svg/redux.svg" />
+                    <img src="images/logo/svg/redux.svg" alt="" />
                     <span class="title_sub_tech">Redux</span>
                 </li>
                 <li class="clip img-circle new">
-                    <img src="images/logo/icons/websocket.png" class="invert"/>
+                    <img src="images/logo/icons/websocket.png" alt="" class="invert"/>
                     <span class="title_sub_tech">Websockets</span>
                 </li>
                 <li class="clip img-circle new">
-                    <img src="images/logo/svg/npm.svg"/>
+                    <img src="images/logo/svg/npm.svg" alt=""/>
                     <span class="title_sub_tech">Npm</span>
                 </li>
                 <li class="clip img-circle new">
-                    <img src="images/logo/svg/webpack.svg"/>
+                    <img src="images/logo/svg/webpack.svg" alt=""/>
                     <span class="title_sub_tech">Webpack</span>
                 </li>
                 <li class="clip img-circle new">
-                    <img src="images/logo/svg/sass.svg" class="height" />
+                    <img src="images/logo/svg/sass.svg" alt="" class="height" />
                     <span class="title_sub_tech">Sass</span>
                 </li>
                 <li class="clip img-circle new">
-                    <img src="images/logo/svg/browsersync.svg" />
+                    <img src="images/logo/svg/browsersync.svg" alt="" />
                     <span class="title_sub_tech">Browsersync</span>
                 </li>
                 <li class="clip img-circle new">
-                    <img src="images/logo/svg/jest.svg" />
+                    <img src="images/logo/svg/jest.svg" alt="" />
                     <span class="title_sub_tech">Jest</span>
                 </li>
                 <li class="clip img-circle new">
-                    <img src="images/logo/svg/cypress.svg" />
+                    <img src="images/logo/svg/cypress.svg" alt="" />
                     <span class="title_sub_tech">Cypress</span>
                 </li>
                 <li class="clip img-circle new">
-                    <img src="images/logo/icons/protractor.png" />
+                    <img src="images/logo/icons/protractor.png" alt="" />
                     <span class="title_sub_tech">Protractor</span>
                 </li>
                 <li class="clear"></li>
@@ -437,147 +437,147 @@ sitemap:
         <div class="row stack-container no-margin">
             <ul class="text-center stacks">
                 <li class="clip img-circle">
-                    <img src="images/logo/svg/spring-boot.svg" />
+                    <img src="images/logo/svg/spring-boot.svg" alt="" />
                     <span class="title_sub_tech">Spring Boot</span>
                 </li>
                 <li class="clip img-circle">
-                    <img src="images/logo/icons/spring.png"/>
+                    <img src="images/logo/icons/spring.png" alt=""/>
                     <span class="title_sub_tech">Spring Security</span>
                 </li>
                 <li class="clip img-circle">
-                    <img src="images/logo/svg/micronaut.svg" />
+                    <img src="images/logo/svg/micronaut.svg" alt="" />
                     <span class="title_sub_tech">Micronaut</span>
                 </li>
                 <li class="clip img-circle new">
-                    <img src="images/logo/icons/netflix.png"/>
+                    <img src="images/logo/icons/netflix.png" alt=""/>
                     <span class="title_sub_tech">Netflix OSS</span>
                 </li>
                 <li class="clip img-circle new">
-                    <img src="images/logo/svg/consul.svg"/>
+                    <img src="images/logo/svg/consul.svg" alt=""/>
                     <span class="title_sub_tech">Consul</span>
                 </li>
                 <li class="clip img-circle new">
-                    <img src="images/logo/icons/gradle.png" class="invert-hover-white"/>
+                    <img src="images/logo/icons/gradle.png" alt="" class="invert-hover-white"/>
                     <span class="title_sub_tech">Gradle</span>
                 </li>
                 <li class="clip img-circle new">
-                    <img src="images/logo/icons/maven.png" class="invert-hover-white width" />
+                    <img src="images/logo/icons/maven.png" alt="" class="invert-hover-white width" />
                     <span class="title_sub_tech">Maven</span>
                 </li>
                 <li class="clip img-circle">
-                    <img src="images/logo/svg/hibernate.svg" />
+                    <img src="images/logo/svg/hibernate.svg" alt="" />
                     <span class="title_sub_tech">Hibernate</span>
                 </li>
                 <li class="clip img-circle new">
-                    <img src="images/logo/icons/liquibase.gif" class="width" />
+                    <img src="images/logo/icons/liquibase.gif" alt="" class="width" />
                     <span class="title_sub_tech">Liquibase</span>
                 </li>
                 <li class="clip img-circle new">
-                    <img src="images/logo/svg/mysql.svg" />
+                    <img src="images/logo/svg/mysql.svg" alt="" />
                     <span class="title_sub_tech">MySQL</span>
                 </li>
                 <li class="clip img-circle new">
-                    <img src="images/logo/svg/mariadb.svg" />
+                    <img src="images/logo/svg/mariadb.svg" alt="" />
                     <span class="title_sub_tech">MariaDB</span>
                 </li>
                 <li class="clip img-circle new">
-                    <img src="images/logo/svg/postgresql.svg" class="height" />
+                    <img src="images/logo/svg/postgresql.svg" alt="" class="height" />
                     <span class="title_sub_tech">PostgreSQL</span>
                 </li>
                 <li class="clip img-circle new">
-                    <img src="images/logo/svg/oracle.svg" class="width" />
+                    <img src="images/logo/svg/oracle.svg" alt="" class="width" />
                     <span class="title_sub_tech">Oracle</span>
                 </li>
                 <li class="clip img-circle new">
-                    <img src="images/logo/icons/mssql.png"/>
+                    <img src="images/logo/icons/mssql.png" alt=""/>
                     <span class="title_sub_tech">MS SQL</span>
                 </li>
                 <li class="clip img-circle new">
-                    <img src="images/logo/icons/mongo.png" />
+                    <img src="images/logo/icons/mongo.png" alt="" />
                     <span class="title_sub_tech">MongoDB</span>
                 </li>
                 <li class="clip img-circle new">
-                    <img src="images/logo/icons/mongock.png" />
+                    <img src="images/logo/icons/mongock.png" alt="" />
                     <span class="title_sub_tech">Mongock</span>
                 </li>
                 <li class="clip img-circle new">
-                    <img src="images/logo/svg//cassandra.svg" class="invert-hover-white" />
+                    <img src="images/logo/svg//cassandra.svg" alt="" class="invert-hover-white" />
                     <span class="title_sub_tech">Cassandra</span>
                 </li>
                 <li class="clip img-circle new">
-                    <img src="images/logo/svg//couchbase.svg"/>
+                    <img src="images/logo/svg//couchbase.svg" alt=""/>
                     <span class="title_sub_tech">Couchbase</span>
                 </li>
                 <li class="clip img-circle new">
-                    <img src="images/logo/svg/neo4j-icon.svg"/>
+                    <img src="images/logo/svg/neo4j-icon.svg" alt=""/>
                     <span class="title_sub_tech">Neo4j</span>
                 </li>
                 <li class="clip img-circle new">
-                    <img src="images/logo/icons/ehcache.png" />
+                    <img src="images/logo/icons/ehcache.png" alt="" />
                     <span class="title_sub_tech">EhCache</span>
                 </li>
                 <li class="clip img-circle new">
-                    <img src="images/logo/icons/caffeine.png" />
+                    <img src="images/logo/icons/caffeine.png" alt="" />
                     <span class="title_sub_tech">Caffeine</span>
                 </li>
                 <li class="clip img-circle new">
-                    <img src="images/logo/icons/Hazelcast.png" class="invert-hover-white"/>
+                    <img src="images/logo/icons/Hazelcast.png" alt="" class="invert-hover-white"/>
                     <span class="title_sub_tech">Hazelcast</span>
                 </li>
                 <li class="clip img-circle new">
-                    <img src="images/logo/icons/infinispan.png" />
+                    <img src="images/logo/icons/infinispan.png" alt="" />
                     <span class="title_sub_tech">Infinispan</span>
                 </li>
                 <li class="clip img-circle new">
-                    <img src="images/logo/icons/memcached.png" />
+                    <img src="images/logo/icons/memcached.png" alt="" />
                     <span class="title_sub_tech">Memcached</span>
                 </li>
                 <li class="clip img-circle new">
-                    <img src="images/logo/icons/redis.png" />
+                    <img src="images/logo/icons/redis.png" alt="" />
                     <span class="title_sub_tech">Redis</span>
                 </li>
                 <li class="clip img-circle new">
-                    <img src="images/logo/svg/elasticsearch.svg"/>
+                    <img src="images/logo/svg/elasticsearch.svg" alt=""/>
                     <span class="title_sub_tech">Elasticsearch</span>
                 </li>
                 <li class="clip img-circle new">
-                    <img src="images/logo/svg/kafka.svg" class="invert-hover-white"/>
+                    <img src="images/logo/svg/kafka.svg" alt="" class="invert-hover-white"/>
                     <span class="title_sub_tech">Kafka</span>
                 </li>
                 <li class="clip img-circle new">
-                    <img src="images/logo/svg/pulsar.svg" class="invert-hover-white"/>
+                    <img src="images/logo/svg/pulsar.svg" alt="" class="invert-hover-white"/>
                     <span class="title_sub_tech">Pulsar</span>
                 </li>
                 <li class="clip img-circle new">
-                    <img src="images/logo/icons/swagger.png"/>
+                    <img src="images/logo/icons/swagger.png" alt=""/>
                     <span class="title_sub_tech">Swagger</span>
                 </li>
                 <li class="clip img-circle new">
-                    <img src="images/logo/icons/elastic-stack.png" class="invert-hover-white"/>
+                    <img src="images/logo/icons/elastic-stack.png" alt="" class="invert-hover-white"/>
                     <span class="title_sub_tech">Elastic Stack</span>
                 </li>
                 <li class="clip img-circle new">
-                    <img src="images/logo/svg/prometheus.svg"/>
+                    <img src="images/logo/svg/prometheus.svg" alt=""/>
                     <span class="title_sub_tech">Prometheus</span>
                 </li>
                 <li class="clip img-circle new">
-                    <img src="images/logo/icons/thymeleaf.png"/>
+                    <img src="images/logo/icons/thymeleaf.png" alt=""/>
                     <span class="title_sub_tech">Thymeleaf</span>
                 </li>
                 <li class="clip img-circle new">
-                    <img src="images/logo/icons/gatling.png"/>
+                    <img src="images/logo/icons/gatling.png" alt=""/>
                     <span class="title_sub_tech">Gatling</span>
                 </li>
                 <li class="clip img-circle new">
-                    <img src="images/logo/svg/cucumber.svg"/>
+                    <img src="images/logo/svg/cucumber.svg" alt=""/>
                     <span class="title_sub_tech">Cucumber</span>
                 </li>
                 <li class="clip img-circle new">
-                    <img src="images/logo/svg/archunit.svg"/>
+                    <img src="images/logo/svg/archunit.svg" alt=""/>
                     <span class="title_sub_tech">ArchUnit</span>
                 </li>
                 <li class="clip img-circle new">
-                    <img src="images/logo/svg/testcontainers.svg"/>
+                    <img src="images/logo/svg/testcontainers.svg" alt=""/>
                     <span class="title_sub_tech">Testcontainers</span>
                 </li>
                 <li class="clear"></li>
@@ -592,39 +592,39 @@ sitemap:
         <div class="row stack-container no-margin">
             <ul class="text-center stacks">
                 <li class="clip img-circle new">
-                    <img src="images/logo/svg/docker.svg"/>
+                    <img src="images/logo/svg/docker.svg" alt=""/>
                     <span class="title_sub_tech">Docker</span>
                 </li>
                 <li class="clip img-circle new">
-                    <img src="images/logo/svg/kubernets.svg"/>
+                    <img src="images/logo/svg/kubernets.svg" alt=""/>
                     <span class="title_sub_tech">Kubernetes</span>
                 </li>
                 <li class="clip img-circle new">
-                    <img src="images/logo/svg/heroku.svg"/>
+                    <img src="images/logo/svg/heroku.svg" alt=""/>
                     <span class="title_sub_tech">Heroku</span>
                 </li>
                 <li class="clip img-circle new">
-                    <img src="images/logo/icons/cf.png" class="invert-hover-white"/>
+                    <img src="images/logo/icons/cf.png" alt="" class="invert-hover-white"/>
                     <span class="title_sub_tech">CloudFoundry</span>
                 </li>
                 <li class="clip img-circle new">
-                    <img src="images/logo/svg/aws.svg" class="width"/>
+                    <img src="images/logo/svg/aws.svg" alt="" class="width"/>
                     <span class="title_sub_tech">AWS</span>
                 </li>
                 <li class="clip img-circle new">
-                    <img src="images/logo/svg/cloudcaptain.svg"/>
+                    <img src="images/logo/svg/cloudcaptain.svg" alt=""/>
                     <span class="title_sub_tech">CloudCaptain</span>
                 </li>
                 <li class="clip img-circle new">
-                    <img src="images/logo/gcp.png"/>
+                    <img src="images/logo/gcp.png" alt=""/>
                     <span class="title_sub_tech">Google Cloud<br/> Platform</span>
                 </li>
                 <li class="clip img-circle new">
-                    <img src="images/logo/svg/openshift.svg"/>
+                    <img src="images/logo/svg/openshift.svg" alt=""/>
                     <span class="title_sub_tech">OpenShift</span>
                 </li>
                 <li class="clip img-circle new">
-                    <img src="images/logo/azure-spring-apps-large.png"/>
+                    <img src="images/logo/azure-spring-apps-large.png" alt=""/>
                     <span class="title_sub_tech">Azure Spring Apps</span>
                 </li>
                 <li class="clear"></li>
@@ -639,27 +639,27 @@ sitemap:
         <div class="row stack-container no-margin">
             <ul class="text-center stacks">
                 <li class="clip img-circle new">
-                    <img src="images/logo/svg/jenkins.svg"/>
+                    <img src="images/logo/svg/jenkins.svg" alt=""/>
                     <span class="title_sub_tech">Jenkins</span>
                 </li>
                 <li class="clip img-circle new">
-                    <img src="images/logo/svg/travis.svg"/>
+                    <img src="images/logo/svg/travis.svg" alt=""/>
                     <span class="title_sub_tech">Travis CI</span>
                 </li>
                 <li class="clip img-circle new">
-                    <img src="images/logo/svg/gitlab.svg"/>
+                    <img src="images/logo/svg/gitlab.svg" alt=""/>
                     <span class="title_sub_tech">GitLab CI</span>
                 </li>
                 <li class="clip img-circle new">
-                    <img src="images/logo/svg/circleci.svg"/>
+                    <img src="images/logo/svg/circleci.svg" alt=""/>
                     <span class="title_sub_tech">CircleCI</span>
                 </li>
                 <li class="clip img-circle new">
-                    <img src="images/logo/azure-pipelines.png"/>
+                    <img src="images/logo/azure-pipelines.png" alt=""/>
                     <span class="title_sub_tech">Azure Pipelines</span>
                 </li>
                 <li class="clip img-circle new">
-                    <img src="images/logo/svg/github-actions.svg"/>
+                    <img src="images/logo/svg/github-actions.svg" alt=""/>
                     <span class="title_sub_tech">Github Workflows</span>
                 </li>
                 <li class="clear"></li>
@@ -779,7 +779,7 @@ function ocCallback(data, divId, txAmount) {
             <div class="thumbnail no-margin-bottom sponsor-col-logo">
                 <div class="logo-container">
                     <div class="logo-container">
-                        <a href="${it.website || it.profile}" target="_blank" rel="noopener" style="padding: 0px"><img src="${it.image || `{{ site.url }}/images/open-collective/${it.name.toLowerCase()}.png`}" class="sponsor-img"></a>
+                        <a href="${it.website || it.profile}" target="_blank" rel="noopener" style="padding: 0px"><img src="${it.image || `{{ site.url }}/images/open-collective/${it.name.toLowerCase()}.png`}" alt="${it.name}" class="sponsor-img"></a>
                     </div>
                     <div class="caption">
                         <a href="${it.website || it.profile}" target="_blank" rel="noopener">${it.name}</a>


### PR DESCRIPTION
Home page: https://www.jhipster.tech/

I added some `alt=""` because the `span` below is explicit and we avoid this error: `Image elements have [alt] attributes that are redundant text`

![image](https://github.com/jhipster/jhipster.github.io/assets/9989211/55327413-5e13-40fd-a40a-1773a13db692)



