### PR TITLE
Fix typo in Zohomail configuration

### DIFF
--- a/tips/011_tip_configuring_email_in_jhipster.md
+++ b/tips/011_tip_configuring_email_in_jhipster.md
@@ -131,7 +131,7 @@ _application-dev.yml_
         profiles:
             active: dev
         mail:
-            host: smtp.zoho.com
+            host: smtp.zoho.eu
             port: 587
             username: zohouserid@zoho.com   #Replace this field with your Zoho username.
             password: ************          #Replace this field with your Zoho password.
@@ -140,7 +140,7 @@ _application-dev.yml_
             properties.mail.smtp:
                 auth: true
                 starttls.enable: true
-                ssl.trust: smtp.zoho.com
+                ssl.trust: smtp.zoho.eu
             [...]
 
 


### PR DESCRIPTION
Zohomail is now using `.eu` extension instead of `.com`.