### PR TITLE
Fix broken links to documentation archive

### DIFF
--- a/docs/customizing-bootstrap-3.mdx
+++ b/docs/customizing-bootstrap-3.mdx
@@ -9,4 +9,4 @@ As of JHipster 5, AngularJS and Bootstrap 3 are not supported anymore with JHips
 
 We have great support for Angular and React, which are both more modern tools, we hope you will enjoy them!
 
-If you still need to use AngularJS 1.x, please have a look at [our archives](/documentation-archive).
+If you still need to use AngularJS 1.x, please have a look at [our archives](/documentation-archive/).

--- a/docs/releases/2015-01-09-jhipster-release-2.0.0.mdx
+++ b/docs/releases/2015-01-09-jhipster-release-2.0.0.mdx
@@ -13,7 +13,7 @@ JHipster release 2.0.0
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2015-01-30-jhipster-release-2.1.0.mdx
+++ b/docs/releases/2015-01-30-jhipster-release-2.1.0.mdx
@@ -13,7 +13,7 @@ JHipster release 2.1.0
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2015-01-31-jhipster-release-2.1.1.mdx
+++ b/docs/releases/2015-01-31-jhipster-release-2.1.1.mdx
@@ -13,7 +13,7 @@ JHipster release 2.1.1
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2015-01-31-jhipster-release-2.2.0.mdx
+++ b/docs/releases/2015-01-31-jhipster-release-2.2.0.mdx
@@ -13,7 +13,7 @@ JHipster release 2.2.0
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2015-02-18-jhipster-release-2.3.0.mdx
+++ b/docs/releases/2015-02-18-jhipster-release-2.3.0.mdx
@@ -13,7 +13,7 @@ JHipster release 2.3.0
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2015-02-24-jhipster-release-2.4.0.mdx
+++ b/docs/releases/2015-02-24-jhipster-release-2.4.0.mdx
@@ -13,7 +13,7 @@ JHipster release 2.4.0
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2015-03-01-jhipster-release-2.5.0.mdx
+++ b/docs/releases/2015-03-01-jhipster-release-2.5.0.mdx
@@ -13,7 +13,7 @@ JHipster release 2.5.0
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2015-03-03-jhipster-release-2.5.1.mdx
+++ b/docs/releases/2015-03-03-jhipster-release-2.5.1.mdx
@@ -13,7 +13,7 @@ JHipster release 2.5.1
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2015-03-06-jhipster-release-2.5.2.mdx
+++ b/docs/releases/2015-03-06-jhipster-release-2.5.2.mdx
@@ -13,7 +13,7 @@ JHipster release 2.5.2
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2015-03-08-jhipster-release-2.6.0.mdx
+++ b/docs/releases/2015-03-08-jhipster-release-2.6.0.mdx
@@ -13,7 +13,7 @@ JHipster release 2.6.0
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2015-04-03-jhipster-release-2.7.0.mdx
+++ b/docs/releases/2015-04-03-jhipster-release-2.7.0.mdx
@@ -13,7 +13,7 @@ JHipster release 2.7.0
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2015-04-20-jhipster-release-2.8.0.mdx
+++ b/docs/releases/2015-04-20-jhipster-release-2.8.0.mdx
@@ -13,7 +13,7 @@ JHipster release 2.8.0
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2015-04-24-jhipster-release-2.9.0.mdx
+++ b/docs/releases/2015-04-24-jhipster-release-2.9.0.mdx
@@ -13,7 +13,7 @@ JHipster release 2.9.0
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2015-04-29-jhipster-release-2.9.1.mdx
+++ b/docs/releases/2015-04-29-jhipster-release-2.9.1.mdx
@@ -13,7 +13,7 @@ JHipster release 2.9.1
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2015-04-29-jhipster-release-2.9.2.mdx
+++ b/docs/releases/2015-04-29-jhipster-release-2.9.2.mdx
@@ -13,7 +13,7 @@ JHipster release 2.9.2
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2015-05-07-jhipster-release-2.10.0.mdx
+++ b/docs/releases/2015-05-07-jhipster-release-2.10.0.mdx
@@ -13,7 +13,7 @@ JHipster release 2.10.0
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2015-05-07-jhipster-release-2.10.1.mdx
+++ b/docs/releases/2015-05-07-jhipster-release-2.10.1.mdx
@@ -13,7 +13,7 @@ JHipster release 2.10.1
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2015-05-15-jhipster-release-2.11.0.mdx
+++ b/docs/releases/2015-05-15-jhipster-release-2.11.0.mdx
@@ -13,7 +13,7 @@ JHipster release 2.11.0
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2015-05-19-jhipster-release-2.11.1.mdx
+++ b/docs/releases/2015-05-19-jhipster-release-2.11.1.mdx
@@ -13,7 +13,7 @@ JHipster release 2.11.1
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2015-05-22-jhipster-release-2.12.0.mdx
+++ b/docs/releases/2015-05-22-jhipster-release-2.12.0.mdx
@@ -13,7 +13,7 @@ JHipster release 2.12.0
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2015-05-28-jhipster-release-2.13.0.mdx
+++ b/docs/releases/2015-05-28-jhipster-release-2.13.0.mdx
@@ -13,7 +13,7 @@ JHipster release 2.13.0
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2015-05-29-jhipster-release-2.13.1.mdx
+++ b/docs/releases/2015-05-29-jhipster-release-2.13.1.mdx
@@ -13,7 +13,7 @@ JHipster release 2.13.1
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2015-05-29-jhipster-release-2.14.1.mdx
+++ b/docs/releases/2015-05-29-jhipster-release-2.14.1.mdx
@@ -13,7 +13,7 @@ JHipster release 2.14.1
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2015-05-31-jhipster-release-2.14.2.mdx
+++ b/docs/releases/2015-05-31-jhipster-release-2.14.2.mdx
@@ -13,7 +13,7 @@ JHipster release 2.14.2
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2015-06-05-jhipster-release-2.15.0.mdx
+++ b/docs/releases/2015-06-05-jhipster-release-2.15.0.mdx
@@ -13,7 +13,7 @@ JHipster release 2.15.0
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2015-06-06-jhipster-release-2.15.1.mdx
+++ b/docs/releases/2015-06-06-jhipster-release-2.15.1.mdx
@@ -13,7 +13,7 @@ JHipster release 2.15.1
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2015-06-07-jhipster-release-2.15.2.mdx
+++ b/docs/releases/2015-06-07-jhipster-release-2.15.2.mdx
@@ -13,7 +13,7 @@ JHipster release 2.15.2
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2015-06-09-jhipster-release-2.16.0.mdx
+++ b/docs/releases/2015-06-09-jhipster-release-2.16.0.mdx
@@ -13,7 +13,7 @@ JHipster release 2.16.0
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2015-06-17-jhipster-release-2.16.1.mdx
+++ b/docs/releases/2015-06-17-jhipster-release-2.16.1.mdx
@@ -13,7 +13,7 @@ JHipster release 2.16.1
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2015-06-30-jhipster-release-2.17.0.mdx
+++ b/docs/releases/2015-06-30-jhipster-release-2.17.0.mdx
@@ -13,7 +13,7 @@ JHipster release 2.17.0
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2015-07-07-jhipster-release-2.18.0.mdx
+++ b/docs/releases/2015-07-07-jhipster-release-2.18.0.mdx
@@ -13,7 +13,7 @@ JHipster release 2.18.0
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2015-07-31-jhipster-release-2.19.0.mdx
+++ b/docs/releases/2015-07-31-jhipster-release-2.19.0.mdx
@@ -13,7 +13,7 @@ JHipster release 2.19.0
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2015-08-25-jhipster-release-2.20.0.mdx
+++ b/docs/releases/2015-08-25-jhipster-release-2.20.0.mdx
@@ -13,7 +13,7 @@ JHipster release 2.20.0
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2015-09-16-jhipster-release-2.21.0.mdx
+++ b/docs/releases/2015-09-16-jhipster-release-2.21.0.mdx
@@ -13,7 +13,7 @@ JHipster release 2.21.0
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2015-09-23-jhipster-release-2.21.1.mdx
+++ b/docs/releases/2015-09-23-jhipster-release-2.21.1.mdx
@@ -13,7 +13,7 @@ JHipster release 2.21.1
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2015-10-06-jhipster-release-2.22.0.mdx
+++ b/docs/releases/2015-10-06-jhipster-release-2.22.0.mdx
@@ -13,7 +13,7 @@ JHipster release 2.22.0
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2015-10-23-jhipster-release-2.23.0.mdx
+++ b/docs/releases/2015-10-23-jhipster-release-2.23.0.mdx
@@ -13,7 +13,7 @@ JHipster release 2.23.0
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2015-11-10-jhipster-release-2.23.1.mdx
+++ b/docs/releases/2015-11-10-jhipster-release-2.23.1.mdx
@@ -13,7 +13,7 @@ JHipster release 2.23.1
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2015-11-20-jhipster-release-2.24.0.mdx
+++ b/docs/releases/2015-11-20-jhipster-release-2.24.0.mdx
@@ -13,7 +13,7 @@ JHipster release 2.24.0
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2015-12-04-jhipster-release-2.25.0.mdx
+++ b/docs/releases/2015-12-04-jhipster-release-2.25.0.mdx
@@ -13,7 +13,7 @@ JHipster release 2.25.0
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2015-12-16-jhipster-release-2.26.0.mdx
+++ b/docs/releases/2015-12-16-jhipster-release-2.26.0.mdx
@@ -13,7 +13,7 @@ JHipster release 2.26.0
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2015-12-17-jhipster-release-2.26.1.mdx
+++ b/docs/releases/2015-12-17-jhipster-release-2.26.1.mdx
@@ -13,7 +13,7 @@ JHipster release 2.26.1
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2015-12-30-jhipster-release-2.26.2.mdx
+++ b/docs/releases/2015-12-30-jhipster-release-2.26.2.mdx
@@ -13,7 +13,7 @@ JHipster release 2.26.2
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2016-01-18-jhipster-release-2.27.0.mdx
+++ b/docs/releases/2016-01-18-jhipster-release-2.27.0.mdx
@@ -13,7 +13,7 @@ JHipster release 2.27.0
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2016-02-23-jhipster-release-2.27.1.mdx
+++ b/docs/releases/2016-02-23-jhipster-release-2.27.1.mdx
@@ -13,7 +13,7 @@ JHipster release 2.27.1
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2016-03-07-jhipster-release-2.27.2.mdx
+++ b/docs/releases/2016-03-07-jhipster-release-2.27.2.mdx
@@ -13,7 +13,7 @@ JHipster release 2.27.2
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/using-angularjs.mdx
+++ b/docs/using-angularjs.mdx
@@ -9,4 +9,4 @@ As of JHipster 5, AngularJS is not supported anymore with JHipster.
 
 We have great support for [Angular](/using-angular) and [React](/using-react), which are both more modern tools, we hope you will enjoy them!
 
-If you still need to use AngularJS 1.x, please have a look at [our archives](/documentation-archive).
+If you still need to use AngularJS 1.x, please have a look at [our archives](/documentation-archive/).


### PR DESCRIPTION
![Image](https://github.com/user-attachments/assets/00b7204a-f9f0-47e4-8af1-1030ff2a5283)