### PR TITLE
Fix documentation archive links

### DIFF
--- a/docs/customizing-bootstrap-3.mdx
+++ b/docs/customizing-bootstrap-3.mdx
@@ -9,4 +9,4 @@ As of JHipster 5, AngularJS and Bootstrap 3 are not supported anymore with JHips
 
 We have great support for Angular and React, which are both more modern tools, we hope you will enjoy them!
 
-If you still need to use AngularJS 1.x, please have a look at [our archives](/documentation-archive).
+If you still need to use AngularJS 1.x, please have a look at [our archives](https://www.jhipster.tech/documentation-archive/).

--- a/docs/releases/2015-01-09-jhipster-release-2.0.0.mdx
+++ b/docs/releases/2015-01-09-jhipster-release-2.0.0.mdx
@@ -13,7 +13,7 @@ JHipster release 2.0.0
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](https://www.jhipster.tech/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2015-01-30-jhipster-release-2.1.0.mdx
+++ b/docs/releases/2015-01-30-jhipster-release-2.1.0.mdx
@@ -13,7 +13,7 @@ JHipster release 2.1.0
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](https://www.jhipster.tech/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2015-01-31-jhipster-release-2.1.1.mdx
+++ b/docs/releases/2015-01-31-jhipster-release-2.1.1.mdx
@@ -13,7 +13,7 @@ JHipster release 2.1.1
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](https://www.jhipster.tech/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2015-01-31-jhipster-release-2.2.0.mdx
+++ b/docs/releases/2015-01-31-jhipster-release-2.2.0.mdx
@@ -13,7 +13,7 @@ JHipster release 2.2.0
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](https://www.jhipster.tech/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2015-02-18-jhipster-release-2.3.0.mdx
+++ b/docs/releases/2015-02-18-jhipster-release-2.3.0.mdx
@@ -13,7 +13,7 @@ JHipster release 2.3.0
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](https://www.jhipster.tech/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2015-02-24-jhipster-release-2.4.0.mdx
+++ b/docs/releases/2015-02-24-jhipster-release-2.4.0.mdx
@@ -13,7 +13,7 @@ JHipster release 2.4.0
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](https://www.jhipster.tech/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2015-03-01-jhipster-release-2.5.0.mdx
+++ b/docs/releases/2015-03-01-jhipster-release-2.5.0.mdx
@@ -13,7 +13,7 @@ JHipster release 2.5.0
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](https://www.jhipster.tech/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2015-03-03-jhipster-release-2.5.1.mdx
+++ b/docs/releases/2015-03-03-jhipster-release-2.5.1.mdx
@@ -13,7 +13,7 @@ JHipster release 2.5.1
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](https://www.jhipster.tech/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2015-03-06-jhipster-release-2.5.2.mdx
+++ b/docs/releases/2015-03-06-jhipster-release-2.5.2.mdx
@@ -13,7 +13,7 @@ JHipster release 2.5.2
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](https://www.jhipster.tech/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2015-03-08-jhipster-release-2.6.0.mdx
+++ b/docs/releases/2015-03-08-jhipster-release-2.6.0.mdx
@@ -13,7 +13,7 @@ JHipster release 2.6.0
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](https://www.jhipster.tech/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2015-04-03-jhipster-release-2.7.0.mdx
+++ b/docs/releases/2015-04-03-jhipster-release-2.7.0.mdx
@@ -13,7 +13,7 @@ JHipster release 2.7.0
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](https://www.jhipster.tech/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2015-04-20-jhipster-release-2.8.0.mdx
+++ b/docs/releases/2015-04-20-jhipster-release-2.8.0.mdx
@@ -13,7 +13,7 @@ JHipster release 2.8.0
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](https://www.jhipster.tech/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2015-04-24-jhipster-release-2.9.0.mdx
+++ b/docs/releases/2015-04-24-jhipster-release-2.9.0.mdx
@@ -13,7 +13,7 @@ JHipster release 2.9.0
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](https://www.jhipster.tech/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2015-04-29-jhipster-release-2.9.1.mdx
+++ b/docs/releases/2015-04-29-jhipster-release-2.9.1.mdx
@@ -13,7 +13,7 @@ JHipster release 2.9.1
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](https://www.jhipster.tech/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2015-04-29-jhipster-release-2.9.2.mdx
+++ b/docs/releases/2015-04-29-jhipster-release-2.9.2.mdx
@@ -13,7 +13,7 @@ JHipster release 2.9.2
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](https://www.jhipster.tech/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2015-05-07-jhipster-release-2.10.0.mdx
+++ b/docs/releases/2015-05-07-jhipster-release-2.10.0.mdx
@@ -13,7 +13,7 @@ JHipster release 2.10.0
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](https://www.jhipster.tech/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2015-05-07-jhipster-release-2.10.1.mdx
+++ b/docs/releases/2015-05-07-jhipster-release-2.10.1.mdx
@@ -13,7 +13,7 @@ JHipster release 2.10.1
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](https://www.jhipster.tech/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2015-05-15-jhipster-release-2.11.0.mdx
+++ b/docs/releases/2015-05-15-jhipster-release-2.11.0.mdx
@@ -13,7 +13,7 @@ JHipster release 2.11.0
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](https://www.jhipster.tech/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2015-05-19-jhipster-release-2.11.1.mdx
+++ b/docs/releases/2015-05-19-jhipster-release-2.11.1.mdx
@@ -13,7 +13,7 @@ JHipster release 2.11.1
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](https://www.jhipster.tech/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2015-05-22-jhipster-release-2.12.0.mdx
+++ b/docs/releases/2015-05-22-jhipster-release-2.12.0.mdx
@@ -13,7 +13,7 @@ JHipster release 2.12.0
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](https://www.jhipster.tech/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2015-05-28-jhipster-release-2.13.0.mdx
+++ b/docs/releases/2015-05-28-jhipster-release-2.13.0.mdx
@@ -13,7 +13,7 @@ JHipster release 2.13.0
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](https://www.jhipster.tech/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2015-05-29-jhipster-release-2.13.1.mdx
+++ b/docs/releases/2015-05-29-jhipster-release-2.13.1.mdx
@@ -13,7 +13,7 @@ JHipster release 2.13.1
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](https://www.jhipster.tech/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2015-05-29-jhipster-release-2.14.1.mdx
+++ b/docs/releases/2015-05-29-jhipster-release-2.14.1.mdx
@@ -13,7 +13,7 @@ JHipster release 2.14.1
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](https://www.jhipster.tech/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2015-05-31-jhipster-release-2.14.2.mdx
+++ b/docs/releases/2015-05-31-jhipster-release-2.14.2.mdx
@@ -13,7 +13,7 @@ JHipster release 2.14.2
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](https://www.jhipster.tech/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2015-06-05-jhipster-release-2.15.0.mdx
+++ b/docs/releases/2015-06-05-jhipster-release-2.15.0.mdx
@@ -13,7 +13,7 @@ JHipster release 2.15.0
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](https://www.jhipster.tech/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2015-06-06-jhipster-release-2.15.1.mdx
+++ b/docs/releases/2015-06-06-jhipster-release-2.15.1.mdx
@@ -13,7 +13,7 @@ JHipster release 2.15.1
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](https://www.jhipster.tech/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2015-06-07-jhipster-release-2.15.2.mdx
+++ b/docs/releases/2015-06-07-jhipster-release-2.15.2.mdx
@@ -13,7 +13,7 @@ JHipster release 2.15.2
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](https://www.jhipster.tech/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2015-06-09-jhipster-release-2.16.0.mdx
+++ b/docs/releases/2015-06-09-jhipster-release-2.16.0.mdx
@@ -13,7 +13,7 @@ JHipster release 2.16.0
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](https://www.jhipster.tech/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2015-06-17-jhipster-release-2.16.1.mdx
+++ b/docs/releases/2015-06-17-jhipster-release-2.16.1.mdx
@@ -13,7 +13,7 @@ JHipster release 2.16.1
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](https://www.jhipster.tech/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2015-06-30-jhipster-release-2.17.0.mdx
+++ b/docs/releases/2015-06-30-jhipster-release-2.17.0.mdx
@@ -13,7 +13,7 @@ JHipster release 2.17.0
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](https://www.jhipster.tech/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2015-07-07-jhipster-release-2.18.0.mdx
+++ b/docs/releases/2015-07-07-jhipster-release-2.18.0.mdx
@@ -13,7 +13,7 @@ JHipster release 2.18.0
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](https://www.jhipster.tech/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2015-07-31-jhipster-release-2.19.0.mdx
+++ b/docs/releases/2015-07-31-jhipster-release-2.19.0.mdx
@@ -13,7 +13,7 @@ JHipster release 2.19.0
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](https://www.jhipster.tech/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2015-08-25-jhipster-release-2.20.0.mdx
+++ b/docs/releases/2015-08-25-jhipster-release-2.20.0.mdx
@@ -13,7 +13,7 @@ JHipster release 2.20.0
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](https://www.jhipster.tech/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2015-09-16-jhipster-release-2.21.0.mdx
+++ b/docs/releases/2015-09-16-jhipster-release-2.21.0.mdx
@@ -13,7 +13,7 @@ JHipster release 2.21.0
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](https://www.jhipster.tech/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2015-09-23-jhipster-release-2.21.1.mdx
+++ b/docs/releases/2015-09-23-jhipster-release-2.21.1.mdx
@@ -13,7 +13,7 @@ JHipster release 2.21.1
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](https://www.jhipster.tech/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2015-10-06-jhipster-release-2.22.0.mdx
+++ b/docs/releases/2015-10-06-jhipster-release-2.22.0.mdx
@@ -13,7 +13,7 @@ JHipster release 2.22.0
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](https://www.jhipster.tech/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2015-10-23-jhipster-release-2.23.0.mdx
+++ b/docs/releases/2015-10-23-jhipster-release-2.23.0.mdx
@@ -13,7 +13,7 @@ JHipster release 2.23.0
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](https://www.jhipster.tech/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2015-11-10-jhipster-release-2.23.1.mdx
+++ b/docs/releases/2015-11-10-jhipster-release-2.23.1.mdx
@@ -13,7 +13,7 @@ JHipster release 2.23.1
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](https://www.jhipster.tech/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2015-11-20-jhipster-release-2.24.0.mdx
+++ b/docs/releases/2015-11-20-jhipster-release-2.24.0.mdx
@@ -13,7 +13,7 @@ JHipster release 2.24.0
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](https://www.jhipster.tech/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2015-12-04-jhipster-release-2.25.0.mdx
+++ b/docs/releases/2015-12-04-jhipster-release-2.25.0.mdx
@@ -13,7 +13,7 @@ JHipster release 2.25.0
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](https://www.jhipster.tech/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2015-12-16-jhipster-release-2.26.0.mdx
+++ b/docs/releases/2015-12-16-jhipster-release-2.26.0.mdx
@@ -13,7 +13,7 @@ JHipster release 2.26.0
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](https://www.jhipster.tech/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2015-12-17-jhipster-release-2.26.1.mdx
+++ b/docs/releases/2015-12-17-jhipster-release-2.26.1.mdx
@@ -13,7 +13,7 @@ JHipster release 2.26.1
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](https://www.jhipster.tech/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2015-12-30-jhipster-release-2.26.2.mdx
+++ b/docs/releases/2015-12-30-jhipster-release-2.26.2.mdx
@@ -13,7 +13,7 @@ JHipster release 2.26.2
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](https://www.jhipster.tech/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2016-01-18-jhipster-release-2.27.0.mdx
+++ b/docs/releases/2016-01-18-jhipster-release-2.27.0.mdx
@@ -13,7 +13,7 @@ JHipster release 2.27.0
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](https://www.jhipster.tech/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2016-02-23-jhipster-release-2.27.1.mdx
+++ b/docs/releases/2016-02-23-jhipster-release-2.27.1.mdx
@@ -13,7 +13,7 @@ JHipster release 2.27.1
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](https://www.jhipster.tech/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2016-03-07-jhipster-release-2.27.2.mdx
+++ b/docs/releases/2016-03-07-jhipster-release-2.27.2.mdx
@@ -13,7 +13,7 @@ JHipster release 2.27.2
 Documentation
 ----------
 
-Looking for the (old) JHipster v2.x documentation? It's [Here](/documentation-archive)!
+Looking for the (old) JHipster v2.x documentation? It's [Here](https://www.jhipster.tech/documentation-archive/)!
 
 What's new
 ----------

--- a/docs/releases/2016-03-23-jhipster-release-3.0.0.mdx
+++ b/docs/releases/2016-03-23-jhipster-release-3.0.0.mdx
@@ -18,7 +18,7 @@ If you liked how easy it is to develop a full-stack application with JHipster 2.
 - JHipster 3 can generate a complete microservices architecture. It will generate and configure microservices, routers, a service registry, monitoring... It's as easy as generating a standard "monolithic" application, but it now works for huge mission-critical, distributed systems.
 - Infrastructure can be completely generated using Docker and Docker Compose. Complex microservices architectures can be run and tested on a laptop, and then deployed in a datacenter or in the cloud. Services can be scaled with one single command.
 
-This website is already up-to-date with the latest documentation (and if you want to access our old 2.x documentation [it's here](/documentation-archive/)), so if you want more information about microservices we recommend you read those new and updated sections:
+This website is already up-to-date with the latest documentation (and if you want to access our old 2.x documentation [it's here](https://www.jhipster.tech/documentation-archive/)), so if you want more information about microservices we recommend you read those new and updated sections:
 
 - [Doing microservices with JHipster](/microservices-architecture/)
 - [Docker and Docker Compose with JHipster](/docker-compose/)

--- a/docs/releases/2018-04-03-jhipster-release-5.0.0-beta.0.mdx
+++ b/docs/releases/2018-04-03-jhipster-release-5.0.0-beta.0.mdx
@@ -58,7 +58,7 @@ Documentation
 We have started to merge the JHipster v5 documentation on the main website:
 
 - It is not yet complete, please don’t hesitate to help if you find issues
-- If you are using JHipster v4, don’t forget we have [the full versioned archives available here](/documentation-archive/).
+- If you are using JHipster v4, don’t forget we have [the full versioned archives available here](https://www.jhipster.tech/documentation-archive/).
 
 What’s missing
 ------------

--- a/docs/releases/2018-05-03-jhipster-release-5.0.0-beta.1.mdx
+++ b/docs/releases/2018-05-03-jhipster-release-5.0.0-beta.1.mdx
@@ -31,7 +31,7 @@ Documentation
 We have started to merge the JHipster v5 documentation on the main website:
 
 - It is not yet complete, please don’t hesitate to help if you find issues
-- If you are using JHipster v4, don’t forget we have [the full versioned archives available here](/documentation-archive/).
+- If you are using JHipster v4, don’t forget we have [the full versioned archives available here](https://www.jhipster.tech/documentation-archive/).
 
 What’s missing
 ------------

--- a/docs/using-angularjs.mdx
+++ b/docs/using-angularjs.mdx
@@ -9,4 +9,4 @@ As of JHipster 5, AngularJS is not supported anymore with JHipster.
 
 We have great support for [Angular](/using-angular) and [React](/using-react), which are both more modern tools, we hope you will enjoy them!
 
-If you still need to use AngularJS 1.x, please have a look at [our archives](/documentation-archive).
+If you still need to use AngularJS 1.x, please have a look at [our archives](https://www.jhipster.tech/documentation-archive/).


### PR DESCRIPTION
Documentation archive is not a part of Docusaurus website, so it's external resource, all external resources url's must be start from http(s) otherwise Docusaurus try use internal routing and show 404 page.