### PR TITLE
Fix docs archive build

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -56,6 +56,12 @@ const config: Config = {
           editUrl: 'https://github.com/jhipster/jhipster.github.io/tree/main/',
           routeBasePath: '/',
           showLastUpdateTime: true,
+          versions: {
+            current: {
+              path: '/',
+            },
+          },
+          onlyIncludeVersions: ['current'],
         },
         blog: false,
         theme: {

--- a/src/components/plugins-pages/MarketplaceDetailsPage/index.tsx
+++ b/src/components/plugins-pages/MarketplaceDetailsPage/index.tsx
@@ -1,5 +1,6 @@
 import Layout from '@theme/Layout';
 import { Redirect, useLocation } from '@docusaurus/router';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 
 import MarketplaceDetailsHero from '@site/src/components/sections/marketplace/MarketplaceDetailsHero';
 import MarketplaceDetails from '@site/src/components/sections/marketplace/MarketplaceDetails';
@@ -7,8 +8,12 @@ import MarketplaceDetails from '@site/src/components/sections/marketplace/Market
 import { useMarketplaceDetails } from '@site/src/hooks/use-marketplace';
 
 export default function MarketplaceDetailsPage() {
+  const { siteConfig } = useDocusaurusContext();
   const location = useLocation();
-  const moduleName = getModuleNameFromPath(location.pathname);
+  const moduleName = getModuleNameFromPath(
+    location.pathname,
+    siteConfig.baseUrl,
+  );
 
   const { details, downloads, isLoading, isValidRoute } =
     useMarketplaceDetails(moduleName);
@@ -37,8 +42,12 @@ export default function MarketplaceDetailsPage() {
   );
 }
 
-function getModuleNameFromPath(pathname: string) {
-  const pathParts = pathname.split('/');
+function getModuleNameFromPath(pathname: string, baseUrl: string) {
+  const normalPathName =
+    baseUrl === '/'
+      ? pathname
+      : pathname.replace(new RegExp(`^${baseUrl}`), '/');
+  const pathParts = normalPathName.split('/');
 
   if (pathParts[4].startsWith('@')) {
     return pathParts

--- a/src/plugins/module-details.ts
+++ b/src/plugins/module-details.ts
@@ -1,3 +1,4 @@
+import type { LoadContext } from '@docusaurus/types';
 import { NPM_SEARCH_MODULES_URL } from '../constants';
 
 import modulesConfig from '../data/modules-config.json';
@@ -12,7 +13,7 @@ function getModulesNames(modules: any): string[] {
   }, []);
 }
 
-export default function moduleDetailsPlugin() {
+export default function moduleDetailsPlugin(context: LoadContext) {
   return {
     name: 'docusaurus-module-details',
     async loadContent() {
@@ -33,7 +34,7 @@ export default function moduleDetailsPlugin() {
 
       content.forEach((moduleName: string) => {
         addRoute({
-          path: `/modules/marketplace/details/${moduleName}`,
+          path: `${context.baseUrl}modules/marketplace/details/${moduleName}`,
           component:
             '@site/src/components/plugins-pages/MarketplaceDetailsPage/index.tsx',
         });


### PR DESCRIPTION
- fix docs archive build:
When we use something like v8.7.1 in baseUrl, the docusaurus docs plugin thinks that this is an internal version and tries to render files by the full path and not finding the file throws an error.
- fix modules details path

Related to https://github.com/jhipster/generator-jhipster/issues/27102#issuecomment-2365342322