### PR TITLE
Add a language switcher

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -41,7 +41,15 @@ const config: Config = {
   // may want to replace "en" with "zh-Hans".
   i18n: {
     defaultLocale: 'en',
-    locales: ['en'],
+    locales: ['en', 'jp'],
+    localeConfigs: {
+      en: {
+        label: 'English',
+      },
+      jp: {
+        label: '日本語',        
+      },
+    },
   },
 
   presets: [
@@ -136,6 +144,10 @@ const config: Config = {
           label: 'JDL Studio',
           position: 'right',
         },
+        {
+          type: 'localeDropdown',
+          position: 'right',
+        },        
       ],
     },
     prism: {


### PR DESCRIPTION
Related to https://github.com/jhipster/jp/issues/36

This is a proposal for a feature allowing the selection of multiple languages on the site.
The envisioned layout for the English site is as follows:

<img width="332" alt="image" src="https://github.com/user-attachments/assets/811fc6d5-d87e-46da-86af-05667f587b52">
