### PR TITLE
Sponsorship page update

### DIFF
--- a/docs/contributing/sponsors.mdx
+++ b/docs/contributing/sponsors.mdx
@@ -39,7 +39,7 @@ We use the OpenCollective APIs to automatically display bronze sponsors on our m
 
 There is a limit to 10 silver sponsors.
 
-Bronze sponsors donate $500 per month to the project.
+Silver sponsors donate $500 per month to the project.
 
 We use the OpenCollective APIs to automatically display bronze sponsors on our main page:
 

--- a/docs/contributing/sponsors.mdx
+++ b/docs/contributing/sponsors.mdx
@@ -51,7 +51,7 @@ We use the OpenCollective APIs to automatically display silver sponsors on our m
 
 There is a limit to 3 gold sponsors.
 
-Bronze sponsors donate $1,000 per month to the project.
+Gold sponsors donate $1,000 per month to the project.
 
 We use the OpenCollective APIs to automatically display gold sponsors on our main page:
 
@@ -63,7 +63,7 @@ We use the OpenCollective APIs to automatically display gold sponsors on our mai
 
 There is a limit to only 1 platinum sponsor.
 
-Bronze sponsors donate $2,500 per month to the project.
+Platinum sponsors donate $2,500 per month to the project.
 
 We use the OpenCollective APIs to automatically display platinum sponsors on our main page:
 

--- a/docs/contributing/sponsors.mdx
+++ b/docs/contributing/sponsors.mdx
@@ -41,7 +41,7 @@ There is a limit to 10 silver sponsors.
 
 Silver sponsors donate $500 per month to the project.
 
-We use the OpenCollective APIs to automatically display bronze sponsors on our main page:
+We use the OpenCollective APIs to automatically display silver sponsors on our main page:
 
 - On the front page of [https://www.jhipster.tech](https://www.jhipster.tech) in the "sponsors" section (about 110,000 views/month).
 - On the GitHub main project page in the "sponsors" section (about 15,000 views/month).
@@ -53,7 +53,7 @@ There is a limit to 3 gold sponsors.
 
 Bronze sponsors donate $1,000 per month to the project.
 
-We use the OpenCollective APIs to automatically display bronze sponsors on our main page:
+We use the OpenCollective APIs to automatically display gold sponsors on our main page:
 
 - On the front page of [https://www.jhipster.tech](https://www.jhipster.tech) in the "sponsors" section (about 110,000 views/month).
 - On the GitHub main project page in the "sponsors" section (about 15,000 views/month).
@@ -65,7 +65,7 @@ There is a limit to only 1 platinum sponsor.
 
 Bronze sponsors donate $2,500 per month to the project.
 
-We use the OpenCollective APIs to automatically display bronze sponsors on our main page:
+We use the OpenCollective APIs to automatically display platinum sponsors on our main page:
 
 - On the front page of [https://www.jhipster.tech](https://www.jhipster.tech) in the "sponsors" section (about 110,000 views/month).
 - On the GitHub main project page in the "sponsors" section (about 15,000 views/month).

--- a/docs/contributing/sponsors.mdx
+++ b/docs/contributing/sponsors.mdx
@@ -29,7 +29,7 @@ We use the Open Collective APIs to automatically display backers on our main pag
 
 Bronze sponsors donate $100 per month to the project.
 
-We use the OpenCollective APIs to automatically display bronze sponsors on our main page:
+We use the Open Collective APIs to automatically display bronze sponsors on our main page:
 
 - On the front page of [https://www.jhipster.tech](https://www.jhipster.tech) in the "sponsors" section (about 110,000 views/month).
 - On the GitHub main project page in the "sponsors" section (about 15,000 views/month).
@@ -41,7 +41,7 @@ There is a limit to 10 silver sponsors.
 
 Silver sponsors donate $500 per month to the project.
 
-We use the OpenCollective APIs to automatically display silver sponsors on our main page:
+We use the Open Collective APIs to automatically display silver sponsors on our main page:
 
 - On the front page of [https://www.jhipster.tech](https://www.jhipster.tech) in the "sponsors" section (about 110,000 views/month).
 - On the GitHub main project page in the "sponsors" section (about 15,000 views/month).
@@ -53,7 +53,7 @@ There is a limit to 3 gold sponsors.
 
 Gold sponsors donate $1,000 per month to the project.
 
-We use the OpenCollective APIs to automatically display gold sponsors on our main page:
+We use the Open Collective APIs to automatically display gold sponsors on our main page:
 
 - On the front page of [https://www.jhipster.tech](https://www.jhipster.tech) in the "sponsors" section (about 110,000 views/month).
 - On the GitHub main project page in the "sponsors" section (about 15,000 views/month).
@@ -65,14 +65,14 @@ There is a limit to only 1 platinum sponsor.
 
 Platinum sponsors donate $2,500 per month to the project.
 
-We use the OpenCollective APIs to automatically display platinum sponsors on our main page:
+We use the Open Collective APIs to automatically display platinum sponsors on our main page:
 
 - On the front page of [https://www.jhipster.tech](https://www.jhipster.tech) in the "sponsors" section (about 110,000 views/month).
 - On the GitHub main project page in the "sponsors" section (about 15,000 views/month).
 
 ## What will the project do with the money?
 
-As you can read in [the OpenCollective documentation](https://docs.opencollective.com), the way your money will be used will be public and totally transparent.
+As you can read in [the Open Collective documentation](https://docs.opencollective.com), the way your money will be used will be public and totally transparent.
 
 Anyone can file an expense. If the expense makes sense for the development of the community, it will be "merged" in the ledger of our open collective by the core contributors and the person who filed the expense will be reimbursed.
 
@@ -91,12 +91,12 @@ Then, money will be used to:
 
 ## Help! I'm a sponsor and my logo doesn't appear!
 
-For each sponsorship level, we use the OpenCollective APIs to automatically display sponsors on our main page. So if your logo doesn't appear:
+For each sponsorship level, we use the Open Collective APIs to automatically display sponsors on our main page. So if your logo doesn't appear:
 
 - Check that you selected a correct sponsorship tier. This needs to be one of the tiers listed above, not a custom contribution.
-- Check your OpenCollective profile to ensure that your logo is uploaded: this is what we'll use to automatically display your logo on our main page.
-- Wait a few minutes: the OpenCollective APIs are cached, so it might take a few minutes for your logo to appear.
+- Check your Open Collective profile to ensure that your logo is uploaded: this is what we'll use to automatically display your logo on our main page.
+- Wait a few minutes: the Open Collective APIs are cached, so it might take a few minutes for your logo to appear.
 
-If those steps don't work, please contact OpenCollective support, as we don't have control over their APIs. They might have a bug or a technical issue that they need to fix.
+If those steps don't work, please contact Open Collective support, as we don't have control over their APIs. They might have a bug or a technical issue that they need to fix.
 
 And please remember the disclaimer at the top of this page: "This is a donation. No goods or services are expected in return. Any requests for refunds for those purposes will be rejected.".

--- a/docs/contributing/sponsors.mdx
+++ b/docs/contributing/sponsors.mdx
@@ -19,7 +19,7 @@ We are a French non-profit organization, as descibed in our [status](/associatio
 
 Backers donate $2 per month to the project.
 
-We use the OpenCollective APIs to automatically display backers on our main page:
+We use the Open Collective APIs to automatically display backers on our main page:
 
 - On the front page of [https://www.jhipster.tech](https://www.jhipster.tech) in the "backers" section (about 110,000 views/month).
 - On the GitHub main project page in the "backers" section (about 15,000 views/month).

--- a/docs/contributing/sponsors.mdx
+++ b/docs/contributing/sponsors.mdx
@@ -13,7 +13,7 @@ Please go to our [Open Collective page](https://opencollective.com/generator-jhi
 
 This is a donation. No goods or services are expected in return. Any requests for refunds for those purposes will be rejected.
 
-We are a French non-profit organization, as descibed in our [status](/association/), and we're not interested in business partnerships.
+We are a French non-profit organization, as described in our [status](/association/), and we're not interested in business partnerships.
 
 ## Benefits of being a backer
 

--- a/docs/contributing/sponsors.mdx
+++ b/docs/contributing/sponsors.mdx
@@ -2,64 +2,73 @@
 title: Sponsors
 slug: /sponsors/
 last_update:
-  date: 2017-11-29T00:00:00-00:00
+  date: 2025-02-01T00:00:00-00:00
 ---
 
 JHipster uses [Open Collective](https://opencollective.com/generator-jhipster) to gather money. This money is used to cover project expenses (like running this website) in a transparent way ([See the Open Collective documentation](https://opencollective.com/how-it-works)), and your donation will help the project live and grow successfully.
 
 Please go to our [Open Collective page](https://opencollective.com/generator-jhipster) to become a backer or a sponsor.
 
+## Disclaimer
+
+This is a donation. No goods or services are expected in return. Any requests for refunds for those purposes will be rejected.
+
+We are a French non-profit organization, as descibed in our [status](/association/), and we're not interested in business partnerships.
 
 ## Benefits of being a backer
 
-Backers donate $2 per month to the project, and get the following benefits:
+Backers donate $2 per month to the project.
 
-- Visibility on the front page of [https://www.jhipster.tech](https://www.jhipster.tech) in the "backers" section (about 110,000 views/month on January, 2018).
-- Visibility on the GitHub main project page in the "backers" section (about 15,000 views/month on January, 2018).
+We use the OpenCollective APIs to automatically display backers on our main page:
+
+- On the front page of [https://www.jhipster.tech](https://www.jhipster.tech) in the "backers" section (about 110,000 views/month).
+- On the GitHub main project page in the "backers" section (about 15,000 views/month).
 
 
 ## Benefits of being a bronze sponsor
 
-Bronze sponsors donate $100 per month to the project, and get the following benefits:
+Bronze sponsors donate $100 per month to the project.
 
-- Visibility on the front page of [https://www.jhipster.tech](https://www.jhipster.tech) in the "sponsors" section (about 110,000 views/month on January, 2018).
-- Visibility on the GitHub main project page in the "sponsors" section (about 15,000 views/month on January, 2018).
+We use the OpenCollective APIs to automatically display bronze sponsors on our main page:
+
+- On the front page of [https://www.jhipster.tech](https://www.jhipster.tech) in the "sponsors" section (about 110,000 views/month).
+- On the GitHub main project page in the "sponsors" section (about 15,000 views/month).
 
 
 ## Benefits of being a silver sponsor
 
 There is a limit to 10 silver sponsors.
 
-Silver sponsors donate $500 per month to the project, and get the following benefits:
+Bronze sponsors donate $500 per month to the project.
 
-- Same benefits as bronze sponsors (visibility on main pages).
-- "Thank you" tweet from [@jhipster](https://twitter.com/jhipster).
-- The ability to create 1 "[bug bounty](/bug-bounties)" every month, non transferable. If that bug bounty is not created by the end of the month, it is lost.
+We use the OpenCollective APIs to automatically display bronze sponsors on our main page:
+
+- On the front page of [https://www.jhipster.tech](https://www.jhipster.tech) in the "sponsors" section (about 110,000 views/month).
+- On the GitHub main project page in the "sponsors" section (about 15,000 views/month).
 
 
 ## Benefits of being a gold sponsor
 
 There is a limit to 3 gold sponsors.
 
-Gold sponsors donate $1,000 per month to the project, and get the following benefits:
+Bronze sponsors donate $1,000 per month to the project.
 
-- Same benefits as silver sponsors (visibility on main pages, and thank you tweet).
-- The ability to create 3 "[bug bounties](/bug-bounties)" every month, non transferable. If all bug bounties are not created by the end of the month, the remaining ones are lost.
-- Company logos on all [https://www.jhipster.tech](https://www.jhipster.tech) page footers (about 550,000 views/month on January, 2018).
+We use the OpenCollective APIs to automatically display bronze sponsors on our main page:
+
+- On the front page of [https://www.jhipster.tech](https://www.jhipster.tech) in the "sponsors" section (about 110,000 views/month).
+- On the GitHub main project page in the "sponsors" section (about 15,000 views/month).
 
 
 ## Benefits of being a platinum sponsor
 
 There is a limit to only 1 platinum sponsor.
 
-The Platinum sponsor donates $2,500 per month to the project, and gets the following benefits:
+Bronze sponsors donate $2,500 per month to the project.
 
-- Same benefits as gold sponsors (visibility on all pages, thank you tweet, 3 bug bounties).
-- Visibility on JHipster Online, with a logo on the welcome page, and on the main page to generate applications.
-- A message to add at the end of each generation. This message will need to be submitted as a PR by the sponsor and will be on each release published during the sponsorship period.
-- The option to add a custom JHipster logo in the official logo list. This logo will be submitted as a PR by the sponsor and will be in the JHipster official logo list. It will need to comply with JHipster's code of conduct.
-- A reserved slot for each JHipster conference organized by the JHipster Developers Association. For organizational reasons, those slots will be reserved starting 3 months after the initial sponsorship payment and will be available until 3 months after the last sponsorship payment.
+We use the OpenCollective APIs to automatically display bronze sponsors on our main page:
 
+- On the front page of [https://www.jhipster.tech](https://www.jhipster.tech) in the "sponsors" section (about 110,000 views/month).
+- On the GitHub main project page in the "sponsors" section (about 15,000 views/month).
 
 ## What will the project do with the money?
 
@@ -79,3 +88,15 @@ Then, money will be used to:
 - Pay for project goodies
 - Pay Meetup fees
 - Pay expenses for developer gatherings: travel & food expenses for core team meetings
+
+## Help! I'm a sponsor and my logo doesn't appear!
+
+For each sponsorship level, we use the OpenCollective APIs to automatically display sponsors on our main page. So if your logo doesn't appear:
+
+- Check that you selected a correct sponsorship tier. This needs to be one of the tiers listed above, not a custom contribution.
+- Check your OpenCollective profile to ensure that your logo is uploaded: this is what we'll use to automatically display your logo on our main page.
+- Wait a few minutes: the OpenCollective APIs are cached, so it might take a few minutes for your logo to appear.
+
+If those steps don't work, please contact OpenCollective support, as we don't have control over their APIs. They might have a bug or a technical issue that they need to fix.
+
+And please remember the disclaimer at the top of this page: "This is a donation. No goods or services are expected in return. Any requests for refunds for those purposes will be rejected.".


### PR DESCRIPTION
Proposal to update the sponsorship page following:

- The new disclaimer that OpenCollective asks us to add
- Our discussion in the association's yearly assembly

I would also modify the OpenCollective sponsorship descriptions accordingly, on https://opencollective.com/generator-jhipster/contribute

If you're a member of the association, please vote or add comments!