### PR TITLE
JHipster 8.9.0 release notes have wrong date in URL

### DIFF
--- a/docs/releases/2025-02-08-jhipster-release-8.9.0.mdx
+++ b/docs/releases/2025-02-08-jhipster-release-8.9.0.mdx
@@ -1,6 +1,6 @@
 ---
 title: Release 8.9.0
-slug: /2024/12/23/jhipster-release-8.9.0.html
+slug: /2025/02/08/jhipster-release-8.9.0.html
 displayed_sidebar: docsSidebar
 sidebar_class_name: hidden
 ---

--- a/redirects.config.ts
+++ b/redirects.config.ts
@@ -103,6 +103,10 @@ const redirectsPlugin = [
         to: '/2023/09/05/jhipster-release-7.9.4.html',
       },
       {
+        from: '/2024/12/23/jhipster-release-8.9.0.html',
+        to: '/2025/02/08/jhipster-release-8.9.0.html',
+      },
+      {
         from: '/blueprints/quarkus.html',
         to: '/blueprints/quarkus/',
       },


### PR DESCRIPTION
Fix https://github.com/jhipster/generator-jhipster/issues/28672