### PR TITLE
Use blank image when missing image from open collective

### DIFF
--- a/src/components/sections/SponsorsAndBackers/OpenCollectiveSponsors/index.tsx
+++ b/src/components/sections/SponsorsAndBackers/OpenCollectiveSponsors/index.tsx
@@ -25,7 +25,7 @@ export default function OpenCollectiveSponsors({ title, sponsors }: Props) {
                   src={
                     item.image ??
                     require(
-                      `@site/static/images/open-collective/${item.name.toLowerCase()}.png`,
+                      `@site/static/images/open-collective/blank.png`,
                     ).default
                   }
                   alt={item.name}


### PR DESCRIPTION
It should fix https://github.com/jhipster/generator-jhipster/issues/29926

But I don't find any unit tests for this