### PR TITLE
Fix deprecation onBrokenMarkdownLinks move to markdown.hooks section

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -33,7 +33,6 @@ const config: Config = {
   projectName: 'jhipster.github.io',
 
   onBrokenLinks: 'throw',
-  onBrokenMarkdownLinks: 'warn',
   onBrokenAnchors: 'ignore',
 
   // Even if you don't use internationalization, you can use this field to set
@@ -51,6 +50,12 @@ const config: Config = {
         baseUrl: '/jp',
       },
     },
+  },
+
+  markdown: {
+    hooks: {
+      onBrokenMarkdownLinks: 'warn',
+    }
   },
 
   presets: [


### PR DESCRIPTION
https://docusaurus.io/docs/api/docusaurus-config#onBrokenMarkdownLinks