### PR TITLE
docs: update the minimum Java version in documentation

### DIFF
--- a/docs/environment/installation.mdx
+++ b/docs/environment/installation.mdx
@@ -29,7 +29,7 @@ In the future, we expect JHipster Online to provide more features.
 
 ### Quick setup
 
-1.  Install Java 17 or 21 LTS. We recommend you use [Eclipse Temurin builds](https://adoptium.net/temurin/releases/?version=21), as they are open source and free.
+1.  Install Java 21 LTS or greater. We recommend you use [Eclipse Temurin builds](https://adoptium.net/temurin/releases/?version=21), as they are open source and free.
 2.  Install Node.js from [the Node.js website](http://nodejs.org/) (please use an LTS 64-bit version, non-LTS versions are not supported)
 3.  Install JHipster: `npm install -g generator-jhipster`
 4.  (optional) If you want to use a module or a blueprint (for instance from the [JHipster Marketplace](/modules/marketplace/)), install [Yeoman](https://yeoman.io/): `npm install -g yo`

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -7,7 +7,7 @@ import Books from '@site/src/components/sections/docs/Books'
 
 ## JHipster Quick Start
 
-1. Install [Java 17](https://adoptium.net/temurin/releases/?version=17), [Node.js](http://nodejs.org/), [Git](http://git-scm.com/) (recommended) and [Docker](docker-compose/) (recommended)
+1. Install [Java 21](https://adoptium.net/temurin/releases/?version=21), [Node.js](http://nodejs.org/), [Git](http://git-scm.com/) (recommended) and [Docker](docker-compose/) (recommended)
 2. Install JHipster `npm install -g generator-jhipster`
 3. Create a new directory and go into it `mkdir myApp && cd myApp`
 4. Run JHipster and follow instructions on screen `jhipster`


### PR DESCRIPTION
The enforcer plugin of the build expects 21+. The documentation still states 17+. Correct where found.