### PR TITLE
Display CodeRabbit as a gold sponsor on the homepage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ yarn-error.log*
 # NetBeans
 nbproject/
 
+
+# impeccable design skill cache
+/.impeccable

--- a/src/components/sections/SponsorsAndBackers/OpenCollectiveSponsors/index.tsx
+++ b/src/components/sections/SponsorsAndBackers/OpenCollectiveSponsors/index.tsx
@@ -9,14 +9,23 @@ import { requireLocalImageIfExists } from '@site/src/lib/utils';
 type Props = {
   title: string;
   sponsors: OpenCollectiveSponsor[];
+  imageSize?: number;
 };
 
-export default function OpenCollectiveSponsors({ title, sponsors }: Props) {
+const DEFAULT_IMAGE_SIZE = 70;
+
+export default function OpenCollectiveSponsors({
+  title,
+  sponsors,
+  imageSize = DEFAULT_IMAGE_SIZE,
+}: Props) {
   if (!sponsors.length) return null;
+
+  const isLarge = imageSize > DEFAULT_IMAGE_SIZE;
 
   return (
     <OpenCollectiveWrapper title={title}>
-      <div className={styles.sectionList}>
+      <div className={clsx(styles.sectionList, isLarge && styles.sectionListLarge)}>
         {sponsors.map((item, idx) => (
           <Link key={`sponsor-${idx}`} href={item.website ?? item.profile}>
             <div className={clsx('card', styles.card)}>
@@ -28,8 +37,8 @@ export default function OpenCollectiveSponsors({ title, sponsors }: Props) {
                     item.image,
                   )}
                   alt={item.name}
-                  width={70}
-                  height={70}
+                  width={imageSize}
+                  height={imageSize}
                   loading="lazy"
                 />
               </div>

--- a/src/components/sections/SponsorsAndBackers/OpenCollectiveSponsors/styles.module.scss
+++ b/src/components/sections/SponsorsAndBackers/OpenCollectiveSponsors/styles.module.scss
@@ -13,6 +13,12 @@
   }
 }
 
+.sectionList.sectionListLarge {
+  & > a {
+    width: auto;
+  }
+}
+
 .card {
   background-color: #ffffff;
   padding: 0.75rem;

--- a/src/components/sections/SponsorsAndBackers/index.tsx
+++ b/src/components/sections/SponsorsAndBackers/index.tsx
@@ -13,7 +13,7 @@ import styles from './styles.module.scss';
 import { useOpenCollective } from './use-open-collective';
 
 export default function SponsorsAndBackers() {
-  const { silverSponsors, bronzeSponsors } = useOpenCollective();
+  const { goldSponsors, silverSponsors, bronzeSponsors } = useOpenCollective();
 
   return (
     <SectionWrapper className={styles.section}>
@@ -35,6 +35,13 @@ export default function SponsorsAndBackers() {
       </SectionDescription>
 
       <OpenCollectiveButton />
+
+      {/* Gold sponsors */}
+      <OpenCollectiveSponsors
+        title="Thank you to our gold sponsors!"
+        sponsors={goldSponsors}
+        imageSize={140}
+      />
 
       {/* Silver sponsors */}
       <OpenCollectiveSponsors

--- a/src/components/sections/SponsorsAndBackers/use-open-collective.ts
+++ b/src/components/sections/SponsorsAndBackers/use-open-collective.ts
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import { openCollectiveService } from '@site/src/lib/services/open-collective';
 
 export const useOpenCollective = () => {
+  const [goldSponsors, setGoldSponsors] = useState<OpenCollectiveSponsor[]>([]);
   const [silverSponsors, setSilverSponsors] = useState<OpenCollectiveSponsor[]>(
     [],
   );
@@ -13,19 +14,21 @@ export const useOpenCollective = () => {
 
   useEffect(() => {
     fetchSponsors().then((data) => {
+      setGoldSponsors(data.goldSponsors);
       setSilverSponsors(data.silverSponsors);
       setBronzeSponsors(data.bronzeSponsors);
     });
   }, []);
 
-  return { silverSponsors, bronzeSponsors };
+  return { goldSponsors, silverSponsors, bronzeSponsors };
 };
 
 async function fetchSponsors() {
-  const [silverSponsors, bronzeSponsors] = await Promise.all([
+  const [goldSponsors, silverSponsors, bronzeSponsors] = await Promise.all([
+    openCollectiveService.getOpenCollective('gold', 1000),
     openCollectiveService.getOpenCollective('silver', 500),
     openCollectiveService.getOpenCollective('bronze', 100),
   ]);
 
-  return { silverSponsors, bronzeSponsors };
+  return { goldSponsors, silverSponsors, bronzeSponsors };
 }

--- a/src/lib/services/open-collective.ts
+++ b/src/lib/services/open-collective.ts
@@ -12,6 +12,10 @@ function sponsorFilter(sponsors: OpenCollectiveSponsor[], amount: number) {
 
 async function getOpenCollective(key: OpenCollectiveKeys, amount: number) {
   const params = {
+    gold: {
+      uri: '/generator-jhipster/tiers/gold-sponsor/all.json',
+      jsonpCallbackFunction: 'ocGoldJsonpCallback',
+    },
     silver: {
       uri: '/generator-jhipster/tiers/silver-sponsor/all.json',
       jsonpCallbackFunction: 'ocSilverJsonpCallback',

--- a/src/types/opencollective.ts
+++ b/src/types/opencollective.ts
@@ -1,4 +1,4 @@
-export type OpenCollectiveKeys = 'silver' | 'bronze';
+export type OpenCollectiveKeys = 'gold' | 'silver' | 'bronze';
 
 export type OpenCollectiveSponsor = {
   MemberId: number;


### PR DESCRIPTION
## What

CodeRabbit recently joined as a **gold sponsor** on [OpenCollective](https://opencollective.com/coderabbit), but they were not showing up on the homepage.

The root cause: the **Sponsors & Backers** section only fetched and rendered the **silver** and **bronze** OpenCollective tiers — there was no gold tier in the code at all, so any gold sponsor was silently dropped.

## Changes

- Add the **gold** tier to the OpenCollective service, hook, types and section (`lastTransactionAmount` = 1000), rendered above silver and bronze.
- Render gold sponsor logos **2× larger** than silver/bronze (140px vs 70px) via a new `imageSize` prop on `OpenCollectiveSponsors`.
- Add a `sectionListLarge` style variant so the larger logo sizes its card to fit instead of being clipped by the fixed column-width grid.

## Notes

- CodeRabbit's logo is served directly from OpenCollective's CDN, so no local asset is required.
- Gold sponsor data is fetched client-side from OpenCollective, like silver and bronze.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>